### PR TITLE
Fix audit rules: add missing perm/arch filters, remove duplicates and typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ roles/*
 !roles/aide
 !roles/apparmor
 !roles/apport
+!roles/auditd
 !roles/cron
 !roles/ssh
 !roles/sudo

--- a/roles/auditd/defaults/main.yml
+++ b/roles/auditd/defaults/main.yml
@@ -1,0 +1,51 @@
+---
+# This option should contain a valid email address or alias.
+auditd_action_mail_acct: "root"
+
+# This parameter tells the system what action to take when the system has detected that it is starting to get low on disk space.
+auditd_admin_space_left_action: "suspend"
+
+# If True, the role applies the auditd rules from the included template file.
+auditd_apply_audit_rules: true
+
+# This parameter tells the system what action to take whenever there is an error detected when writing audit events to disk or rotating logs.
+auditd_disk_error_action: "suspend"
+
+# This parameter tells the system what action to take when the system has detected that the partition to which log files are written has become full.
+auditd_disk_full_action: "suspend"
+
+# Set enabled flag for auditd service.
+auditd_enable_flag: 2
+
+# When to flush the audit records to disk.
+auditd_flush: "incremental_async"
+
+# If True, the audit daemon will ignore errors when reading rules from a file.
+auditd_ignore_errors: false
+
+# This keyword specifies the maximum file size in megabytes. When this limit is reached, it will trigger a configurable action.
+auditd_max_log_file: 20
+
+# This parameter tells the system what action to take when the system has detected that the max file size limit has been reached.
+auditd_max_log_file_action: "rotate"
+
+# Set failure mode.
+auditd_mode: 1
+
+# Specifies the number of log files to keep if rotate is given as the max_log_file_action.
+auditd_num_logs: 5
+
+# If the free space in the filesystem containing log_file drops below this value (in mb), the audit daemon takes the action specified by space_left_action.
+auditd_space_left: 75
+
+# This parameter tells the system what action to take when the system has detected that it is starting to get low on disk space.
+auditd_space_left_action: "email"
+
+# Set the audit backlog limit in the GRUB command line.
+grub_audit_backlog_cmdline: "audit_backlog_limit=8192"
+
+# Enable auditd in the GRUB command line.
+grub_audit_cmdline: "audit=1"
+
+# auditd rules template location.
+hardening_rules_template: "etc/audit/rules.d/hardening.rules.j2"

--- a/roles/auditd/handlers/main.yml
+++ b/roles/auditd/handlers/main.yml
@@ -1,0 +1,34 @@
+---
+- name: Generate auditd rules
+  become: true
+  ansible.builtin.command:
+    cmd: augenrules
+  register: augenrules_handler
+  changed_when:
+    - augenrules_handler.rc == 0
+
+- name: Enable auditd
+  become: true
+  ansible.builtin.service:
+    name: auditd
+    enabled: true
+  when:
+    - ansible_facts.virtualization_type not in ["container", "docker", "podman"]
+
+- name: Update GRUB
+  become: true
+  ansible.builtin.command:
+    cmd: update-grub
+  register: update_grub
+  changed_when: update_grub.rc == 0
+  when:
+    - ansible_facts.virtualization_type not in ["container", "docker", "podman"]
+
+- name: Update GRUB2
+  become: true
+  ansible.builtin.command:
+    cmd: grub2-mkconfig
+  register: update_grub2
+  changed_when: update_grub2.rc == 0
+  when:
+    - ansible_facts.virtualization_type not in ["container", "docker", "podman"]

--- a/roles/auditd/handlers/main.yml
+++ b/roles/auditd/handlers/main.yml
@@ -23,12 +23,3 @@
   changed_when: update_grub.rc == 0
   when:
     - ansible_facts.virtualization_type not in ["container", "docker", "podman"]
-
-- name: Update GRUB2
-  become: true
-  ansible.builtin.command:
-    cmd: grub2-mkconfig
-  register: update_grub2
-  changed_when: update_grub2.rc == 0
-  when:
-    - ansible_facts.virtualization_type not in ["container", "docker", "podman"]

--- a/roles/auditd/meta/argument_specs.yml
+++ b/roles/auditd/meta/argument_specs.yml
@@ -75,7 +75,7 @@ argument_specs:
       auditd_ignore_errors:
         description: "If True, the audit daemon will ignore errors when reading rules from a file."
         type: "bool"
-        default: false
+        default: "False"
       auditd_max_log_file:
         description: "This keyword specifies the maximum file size in megabytes. When this limit is reached, it will trigger a configurable action."
         type: "int"

--- a/roles/auditd/meta/argument_specs.yml
+++ b/roles/auditd/meta/argument_specs.yml
@@ -1,0 +1,129 @@
+---
+argument_specs:
+  main:
+    short_description: Installation and configuration of auditd
+    description:
+      - Installation and configuration of auditd.
+    author:
+      - konstruktoid
+    options:
+      auditd_apply_audit_rules:
+        description: "If True, the role applies the auditd rules from the included template file."
+        type: "bool"
+        default: "True"
+      auditd_action_mail_acct:
+        description: "This option should contain a valid email address or alias."
+        type: "str"
+        default: "root"
+      auditd_admin_space_left_action:
+        description: "This parameter tells the system what action to take when the system has detected that it is starting to get low on disk space."
+        type: "str"
+        default: "suspend"
+        choices:
+          - "email"
+          - "exec"
+          - "halt"
+          - "ignore"
+          - "rotate"
+          - "single"
+          - "suspend"
+          - "syslog"
+      auditd_disk_error_action:
+        description: "This parameter tells the system what action to take whenever there is an error detected."
+        type: "str"
+        default: "suspend"
+        choices:
+          - "email"
+          - "exec"
+          - "halt"
+          - "ignore"
+          - "rotate"
+          - "single"
+          - "suspend"
+          - "syslog"
+      auditd_disk_full_action:
+        description: "This parameter tells the system what action to take when the system has detected that the partition to which log files are is full."
+        type: "str"
+        default: "suspend"
+        choices:
+          - "email"
+          - "exec"
+          - "halt"
+          - "ignore"
+          - "rotate"
+          - "single"
+          - "suspend"
+          - "syslog"
+      auditd_enable_flag:
+        description: "Set enabled flag for auditd service."
+        type: "int"
+        default: 2
+        choices:
+          - 0
+          - 1
+          - 2
+      auditd_flush:
+        description: "When to flush the audit records to disk."
+        type: "str"
+        default: "incremental_async"
+        choices:
+          - "data"
+          - "incremental_async"
+          - "incremental"
+          - "none"
+          - "sync"
+      auditd_ignore_errors:
+        description: "If True, the audit daemon will ignore errors when reading rules from a file."
+        type: "bool"
+        default: false
+      auditd_max_log_file:
+        description: "This keyword specifies the maximum file size in megabytes. When this limit is reached, it will trigger a configurable action."
+        type: "int"
+        default: 20
+      auditd_max_log_file_action:
+        description: "This parameter tells the system what action to take when the system has detected that the max file size limit has been reached."
+        type: "str"
+        default: "rotate"
+        choices:
+          - "ignore"
+          - "keep_logs"
+          - "rotate"
+          - "syslog"
+          - "suspend"
+      auditd_mode:
+        description: "Set failure mode."
+        type: "int"
+        default: 1
+        choices:
+          - 0
+          - 1
+          - 2
+      auditd_num_logs:
+        description: "Specifies the number of log files to keep if rotate is given as the max_log_file_action."
+        type: "int"
+        default: 5
+      auditd_space_left:
+        description: "If the free space in the filesystem containing log_file drops below this value (in mb), the audit daemon takes the action specified by space_left_action." # noqa: yaml[line-length]
+        type: "int"
+        default: 75
+      auditd_space_left_action:
+        description: "This parameter tells the system what action to take when the system has detected that it is starting to get low on disk space."
+        type: "str"
+        default: "email"
+        choices:
+          - "email"
+          - "exec"
+          - "halt"
+          - "ignore"
+          - "rotate"
+          - "single"
+          - "suspend"
+          - "syslog"
+      grub_audit_backlog_cmdline:
+        description: "Set the audit backlog limit in the GRUB command line."
+        type: "str"
+        default: "audit_backlog_limit=8192"
+      grub_audit_cmdline:
+        description: "Enable auditd in the GRUB command line."
+        type: "str"
+        default: "audit=1"

--- a/roles/auditd/meta/main.yml
+++ b/roles/auditd/meta/main.yml
@@ -1,0 +1,30 @@
+---
+galaxy_info:
+  role_name: auditd
+  author: konstruktoid
+  description: AlmaLinux, Debian and Ubuntu hardening. systemd edition.
+  license: apache
+  min_ansible_version: "2.18"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+    - name: EL
+      versions:
+        - "9"
+        - "10"
+    - name: Ubuntu
+      versions:
+        - jammy
+        - noble
+  galaxy_tags:
+    - almalinux
+    - centos
+    - cis
+    - debian
+    - disa
+    - hardening
+    - security
+    - system
+    - systemd
+    - ubuntu

--- a/roles/auditd/meta/main.yml
+++ b/roles/auditd/meta/main.yml
@@ -2,7 +2,7 @@
 galaxy_info:
   role_name: auditd
   author: konstruktoid
-  description: AlmaLinux, Debian and Ubuntu hardening. systemd edition.
+  description: Install and configure auditd and manage audit rules on AlmaLinux, Debian, and Ubuntu.
   license: apache
   min_ansible_version: "2.18"
   platforms:

--- a/roles/auditd/molecule/almalinux/molecule.yml
+++ b/roles/auditd/molecule/almalinux/molecule.yml
@@ -1,0 +1,77 @@
+---
+dependency:
+  name: galaxy
+  enabled: true
+driver:
+  name: vagrant
+  provider:
+    name: virtualbox
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      callback_whitelist: profile_tasks
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..:/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
+  playbooks:
+    converge: ../default/converge.yml
+    verify: ../default/verify.yml
+  log: true
+  inventory:
+    host_vars:
+      almalinux9:
+      almalinux10:
+platforms:
+  - name: almalinux9
+    box: bento/almalinux-9
+    config_options:
+      vm.boot_timeout: 600
+    instance_raw_config_args:
+      - vbguest.auto_update = false
+    memory: 2048
+  - name: almalinux10
+    box: almalinux/10-kitten-x86_64_v2
+    config_options:
+      vm.boot_timeout: 600
+    instance_raw_config_args:
+      - vbguest.auto_update = false
+    memory: 2048
+verifier:
+  name: ansible
+scenario:
+  name: almalinux
+  create_sequence:
+    - dependency
+    - create
+    - prepare
+  check_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - create
+    - prepare
+    - converge
+    - check
+    - destroy
+  converge_sequence:
+    - dependency
+    - create
+    - prepare
+    - converge
+  destroy_sequence:
+    - dependency
+    - cleanup
+    - destroy
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - side_effect
+    - verify
+    - cleanup
+    - destroy

--- a/roles/auditd/molecule/custom/molecule.yml
+++ b/roles/auditd/molecule/custom/molecule.yml
@@ -1,0 +1,73 @@
+---
+dependency:
+  name: galaxy
+  enabled: true
+driver:
+  name: vagrant
+  provider:
+    name: virtualbox
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      callback_whitelist: profile_tasks
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..:/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
+  playbooks:
+    converge: ../default/converge.yml
+    verify: ../default/verify.yml
+  log: true
+  inventory:
+    host_vars:
+      jammy:
+platforms:
+  - name: jammy
+    box: bento/ubuntu-22.04
+    config_options:
+      vm.boot_timeout: 600
+      synced_folder: false
+    provider_raw_config_args:
+      - customize ['modifyvm', :id, '--uart1', '0x3F8', '4']
+      - customize ['modifyvm', :id, '--uartmode1', 'file', File::NULL]
+    instance_raw_config_args:
+      - vbguest.auto_update = false
+    memory: 1024
+verifier:
+  name: ansible
+scenario:
+  name: custom
+  create_sequence:
+    - dependency
+    - create
+    - prepare
+  check_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - create
+    - prepare
+    - converge
+    - check
+    - destroy
+  converge_sequence:
+    - dependency
+    - create
+    - prepare
+    - converge
+  destroy_sequence:
+    - dependency
+    - cleanup
+    - destroy
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - side_effect
+    - verify
+    - cleanup
+    - destroy

--- a/roles/auditd/molecule/debian/molecule.yml
+++ b/roles/auditd/molecule/debian/molecule.yml
@@ -1,0 +1,79 @@
+---
+dependency:
+  name: galaxy
+  enabled: true
+driver:
+  name: vagrant
+  provider:
+    name: virtualbox
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      callback_whitelist: profile_tasks
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..:/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
+  playbooks:
+    converge: ../default/converge.yml
+    verify: ../default/verify.yml
+  log: true
+  inventory:
+    host_vars:
+      bookworm:
+      testing:
+      trixie:
+platforms:
+  - name: bookworm
+    box: debian/bookworm64
+    instance_raw_config_args:
+      - vbguest.auto_update = false
+    memory: 1024
+  - name: testing
+    box: debian/testing64
+    instance_raw_config_args:
+      - vbguest.auto_update = false
+    memory: 1024
+  - name: trixie
+    box: bento/debian-13
+    instance_raw_config_args:
+      - vbguest.auto_update = false
+    memory: 1024
+verifier:
+  name: ansible
+scenario:
+  name: debian
+  create_sequence:
+    - dependency
+    - create
+    - prepare
+  check_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - create
+    - prepare
+    - converge
+    - check
+    - destroy
+  converge_sequence:
+    - dependency
+    - create
+    - prepare
+    - converge
+  destroy_sequence:
+    - dependency
+    - cleanup
+    - destroy
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - side_effect
+    - verify
+    - cleanup
+    - destroy

--- a/roles/auditd/molecule/default/converge.yml
+++ b/roles/auditd/molecule/default/converge.yml
@@ -1,0 +1,26 @@
+---
+- name: Converge
+  hosts: all
+  any_errors_fatal: true
+  tasks:
+    - name: Install OpenSSL on AlmaLinux
+      become: true
+      ansible.builtin.dnf:
+        name: openssl
+        state: present
+      when:
+        - ansible_facts.distribution == 'AlmaLinux'
+
+    - name: Install acl on Debian
+      become: true
+      ansible.builtin.apt:
+        name: acl
+        state: present
+        install_recommends: false
+        update_cache: true
+      when:
+        - ansible_facts.os_family == 'Debian'
+
+    - name: Include Ansible role
+      ansible.builtin.import_role:
+        name: konstruktoid.hardening.auditd

--- a/roles/auditd/molecule/default/molecule.yml
+++ b/roles/auditd/molecule/default/molecule.yml
@@ -1,0 +1,86 @@
+---
+dependency:
+  name: galaxy
+  enabled: true
+driver:
+  name: vagrant
+  provider:
+    name: virtualbox
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      callback_whitelist: profile_tasks
+  log: true
+  inventory:
+    host_vars:
+      almalinux10:
+      trixie:
+      noble:
+platforms:
+  - name: almalinux10
+    box: almalinux/10-kitten-x86_64_v2
+    config_options:
+      vm.boot_timeout: 600
+      ssh.key_type: ed25519
+    instance_raw_config_args:
+      - vbguest.auto_update = false
+    memory: 2048
+  - name: trixie
+    box: bento/debian-13
+    config_options:
+      ssh.key_type: ed25519
+    instance_raw_config_args:
+      - vbguest.auto_update = false
+    memory: 1024
+  - name: noble
+    box: bento/ubuntu-24.04
+    config_options:
+      vm.boot_timeout: 600
+      ssh.key_type: ed25519
+    instance_raw_config_args:
+      - vbguest.auto_update = false
+    provider_raw_config_args:
+      - customize ["modifyvm", :id, "--cableconnected1", "on"]
+      - customize ['modifyvm', :id, '--uart1', '0x3F8', '4']
+      - customize ['modifyvm', :id, '--uartmode1', 'file', File::NULL]
+    memory: 1024
+verifier:
+  name: ansible
+scenario:
+  name: default
+  create_sequence:
+    - dependency
+    - create
+    - prepare
+  check_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - create
+    - prepare
+    - converge
+    - check
+    - destroy
+  converge_sequence:
+    - dependency
+    - create
+    - prepare
+    - converge
+  destroy_sequence:
+    - dependency
+    - cleanup
+    - destroy
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - side_effect
+    - verify
+    - cleanup
+    - destroy

--- a/roles/auditd/molecule/default/verify.yml
+++ b/roles/auditd/molecule/default/verify.yml
@@ -1,0 +1,119 @@
+---
+- name: Verify
+  hosts: all
+  any_errors_fatal: true
+  tasks:
+    - name: Reboot and reconnect
+      when:
+        - ansible_facts.virtualization_type not in ["container", "docker", "podman"]
+      block:
+        - name: Reboot host
+          become: true
+          ansible.builtin.reboot:
+
+        - name: Wait for the host and reconnect
+          ansible.builtin.wait_for:
+            port: 22
+            host: "{{ (ansible_facts.ssh_host | default(ansible_facts.host)) | default(inventory_hostname) }}"
+            delay: 10
+            timeout: 120
+
+    - name: Include default vars
+      ansible.builtin.include_vars:
+        dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/defaults/"
+        extensions:
+          - yml
+
+    - name: Include host vars
+      ansible.builtin.include_vars:
+        file: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/inventory/host_vars/{{ ansible_facts.hostname }}"
+
+    - name: Verify auditd
+      become: true
+      when:
+        - ansible_facts.virtualization_type not in ["container", "docker", "podman"]
+        - manage_auditd
+      block:
+        - name: Verify auditd configuration
+          ansible.builtin.lineinfile:
+            dest: /etc/audit/auditd.conf
+            line: "{{ item }}"
+            state: present
+          check_mode: true
+          register: auditd_conf
+          failed_when: auditd_conf is changed
+          with_items:
+            - action_mail_acct = {{ auditd_action_mail_acct }}
+            - admin_space_left_action = {{ auditd_admin_space_left_action }}
+            - disk_error_action = {{ auditd_disk_error_action }}
+            - disk_full_action = {{ auditd_disk_full_action }}
+            - flush = {{ auditd_flush }}
+            - max_log_file = {{ auditd_max_log_file }}
+            - max_log_file_action = {{ auditd_max_log_file_action }}
+            - name_format = hostname
+            - num_logs = {{ auditd_num_logs }}
+            - space_left = {{ auditd_space_left }}
+            - space_left_action = {{ auditd_space_left_action }}
+
+        - name: Verify auditd rules
+          become: true
+          ansible.builtin.shell:
+            cmd: |
+              set -o pipefail
+              auditctl -l | grep "^{{ item }}$"
+          register: auditd_rules
+          changed_when: false
+          failed_when: auditd_rules.rc != 0
+          args:
+            executable: /bin/bash
+          loop:
+            - "-a always,exit -F arch=b32 -S open -F dir=/etc -F success=0 -F key=access"
+            - "-a always,exit -F arch=b32 -S open -F dir=/tmp -F success=0 -F key=access"
+            - "-a always,exit -F arch=b32 -S open -F dir=/var -F success=0 -F key=access"
+            - "-a always,exit .* key=actions"
+            - "-a always,exit .* key=audispconfig"
+            - "-a always,exit .* key=audit_rules_usergroup_modification"
+            - "-a always,exit .* key=audit_time_rules"
+            - "-a always,exit .* key=cron"
+            - "-a always,exit .* path=/etc/ld.so.conf .* key=libpath"
+
+        - name: Verify auditd settings
+          ansible.builtin.shell:
+            cmd: |
+              set -o pipefail
+              grep "^{{ item }}$" /etc/audit/audit.rules
+          register: auditd_settings
+          changed_when: false
+          failed_when: auditd_settings.rc != 0
+          args:
+            executable: /bin/bash
+          loop:
+            - "{{ '-i' if auditd_ignore_errors else '-c' }}"
+            - "-f {{ auditd_mode | int }}"
+            - "-e {{ auditd_enable_flag }}"
+
+    - name: Verify GRUB settings
+      become: true
+      when:
+        - ansible_facts.virtualization_type not in ["container", "docker", "podman"]
+      block:
+        - name: Verify RedHat GRUB audit settings
+          ansible.builtin.shell: |
+            set -o pipefail
+            grubby --info="/boot/vmlinuz-$(uname -r)" | grep "^args.*{{ grub_audit_cmdline }} {{ grub_audit_backlog_cmdline }}"
+          register: audit_grubenv
+          changed_when: false
+          failed_when: audit_grubenv.rc != 0
+          when:
+            - ansible_facts.os_family == "RedHat"
+            - manage_auditd
+
+        - name: Verify Debian audit GRUB settings
+          ansible.builtin.shell:
+            cmd: grep "linux.*{{ grub_audit_cmdline }} {{ grub_audit_backlog_cmdline }}" /boot/grub/grub.cfg
+          register: audit_grub_cfg
+          changed_when: false
+          failed_when: audit_grub_cfg.rc != 0
+          when:
+            - ansible_facts.os_family == "Debian"
+            - manage_auditd

--- a/roles/auditd/molecule/default/verify.yml
+++ b/roles/auditd/molecule/default/verify.yml
@@ -32,7 +32,6 @@
       become: true
       when:
         - ansible_facts.virtualization_type not in ["container", "docker", "podman"]
-        - manage_auditd
       block:
         - name: Verify auditd configuration
           ansible.builtin.lineinfile:
@@ -106,7 +105,6 @@
           failed_when: audit_grubenv.rc != 0
           when:
             - ansible_facts.os_family == "RedHat"
-            - manage_auditd
 
         - name: Verify Debian audit GRUB settings
           ansible.builtin.shell:
@@ -116,4 +114,3 @@
           failed_when: audit_grub_cfg.rc != 0
           when:
             - ansible_facts.os_family == "Debian"
-            - manage_auditd

--- a/roles/auditd/molecule/docker/molecule.yml
+++ b/roles/auditd/molecule/docker/molecule.yml
@@ -1,0 +1,67 @@
+---
+dependency:
+  name: galaxy
+  enabled: true
+driver:
+  name: docker
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      callback_whitelist: profile_tasks
+  playbooks:
+    converge: ../default/converge.yml
+    verify: ../default/verify.yml
+  log: true
+  inventory:
+    host_vars:
+      bookworm:
+      noble:
+platforms:
+  - name: bookworm
+    image: docker.io/debian:bookworm
+    privileged: true
+    volume_mounts:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - name: noble
+    image: docker.io/ubuntu:noble
+    privileged: true
+    volume_mounts:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+verifier:
+  name: ansible
+scenario:
+  name: docker
+  create_sequence:
+    - dependency
+    - create
+    - prepare
+  check_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - create
+    - prepare
+    - converge
+    - check
+    - destroy
+  converge_sequence:
+    - dependency
+    - create
+    - prepare
+    - converge
+  destroy_sequence:
+    - dependency
+    - cleanup
+    - destroy
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/roles/auditd/molecule/single/molecule.yml
+++ b/roles/auditd/molecule/single/molecule.yml
@@ -1,0 +1,69 @@
+---
+dependency:
+  name: galaxy
+  enabled: true
+driver:
+  name: vagrant
+  provider:
+    name: virtualbox
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      callback_whitelist: profile_tasks
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..:/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
+  playbooks:
+    converge: ../default/converge.yml
+    verify: ../default/verify.yml
+  log: true
+  inventory:
+    host_vars:
+      noble:
+platforms:
+  - name: noble
+    box: bento/ubuntu-24.04
+    config_options:
+      vm.boot_timeout: 600
+    instance_raw_config_args:
+      - vbguest.auto_update = false
+    memory: 1024
+verifier:
+  name: ansible
+scenario:
+  name: single
+  create_sequence:
+    - dependency
+    - create
+    - prepare
+  check_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - create
+    - prepare
+    - converge
+    - check
+    - destroy
+  converge_sequence:
+    - dependency
+    - create
+    - prepare
+    - converge
+  destroy_sequence:
+    - dependency
+    - cleanup
+    - destroy
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - side_effect
+    - verify
+    - cleanup
+    - destroy

--- a/roles/auditd/molecule/ubuntu/molecule.yml
+++ b/roles/auditd/molecule/ubuntu/molecule.yml
@@ -1,0 +1,97 @@
+---
+dependency:
+  name: galaxy
+  enabled: true
+driver:
+  name: vagrant
+  provider:
+    name: virtualbox
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      callback_whitelist: profile_tasks
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..:/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
+  playbooks:
+    converge: ../default/converge.yml
+    verify: ../default/verify.yml
+  log: true
+  inventory:
+    host_vars:
+      noble:
+      questing:
+      resolute:
+platforms:
+  - name: noble
+    box: bento/ubuntu-24.04
+    config_options:
+      vm.boot_timeout: 600
+      ssh.key_type: ed25519
+    instance_raw_config_args:
+      - vbguest.auto_update = false
+    provider_raw_config_args:
+      - customize ["modifyvm", :id, "--cableconnected1", "on"]
+      - customize ['modifyvm', :id, '--uart1', '0x3F8', '4']
+      - customize ['modifyvm', :id, '--uartmode1', 'file', File::NULL]
+  - name: questing
+    box: konstruktoid/ubuntu-25.10
+    config_options:
+      vm.boot_timeout: 600
+      ssh.key_type: ed25519
+    instance_raw_config_args:
+      - vbguest.auto_update = false
+    provider_raw_config_args:
+      - customize ["modifyvm", :id, "--cableconnected1", "on"]
+      - customize ['modifyvm', :id, '--uart1', '0x3F8', '4']
+      - customize ['modifyvm', :id, '--uartmode1', 'file', File::NULL]
+  - name: resolute
+    box: konstruktoid/ubuntu-26.04
+    config_options:
+      vm.boot_timeout: 600
+      ssh.key_type: ed25519
+    instance_raw_config_args:
+      - vbguest.auto_update = false
+    provider_raw_config_args:
+      - customize ["modifyvm", :id, "--cableconnected1", "on"]
+      - customize ['modifyvm', :id, '--uart1', '0x3F8', '4']
+      - customize ['modifyvm', :id, '--uartmode1', 'file', File::NULL]
+verifier:
+  name: ansible
+scenario:
+  name: ubuntu
+  create_sequence:
+    - dependency
+    - create
+    - prepare
+  check_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - create
+    - prepare
+    - converge
+    - check
+    - destroy
+  converge_sequence:
+    - dependency
+    - create
+    - prepare
+    - converge
+  destroy_sequence:
+    - dependency
+    - cleanup
+    - destroy
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - side_effect
+    - verify
+    - cleanup
+    - destroy

--- a/roles/auditd/tasks/main.yml
+++ b/roles/auditd/tasks/main.yml
@@ -167,6 +167,8 @@
         line: active = yes
         state: present
         mode: "0640"
+        owner: root
+        group: root
         create: true
 
     - name: Add auditd rules

--- a/roles/auditd/tasks/main.yml
+++ b/roles/auditd/tasks/main.yml
@@ -1,0 +1,184 @@
+---
+- name: Configure auditd
+  become: true
+  block:
+    - name: Update apt cache
+      ansible.builtin.apt:
+        update_cache: true
+      when:
+        - ansible_facts.os_family == "Debian"
+
+    - name: Install audit package
+      ansible.builtin.package:
+        name: "{{ 'auditd' if ansible_facts.os_family == 'Debian' else 'audit' }}"
+        state: present
+
+    - name: Install initscripts
+      ansible.builtin.package:
+        name: initscripts
+        state: present
+      when:
+        - ansible_facts.os_family == "RedHat"
+
+    - name: Install audit-rules
+      ansible.builtin.package:
+        name: audit-rules
+        state: present
+      when:
+        - ansible_facts.distribution == "AlmaLinux"
+        - ansible_facts.distribution_major_version | int >= 10
+
+    - name: Ensure /etc/audit/rules.d exists
+      ansible.builtin.file:
+        path: /etc/audit/rules.d
+        state: directory
+        mode: "0755"
+        owner: root
+        group: root
+
+    - name: Configure Debian auditd GRUB cmdline
+      ansible.builtin.lineinfile:
+        line: GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX {{ grub_audit_cmdline }} {{ grub_audit_backlog_cmdline }}"
+        regexp: "^GRUB_CMDLINE_LINUX="
+        dest: /etc/default/grub.d/99-hardening-audit.cfg
+        state: present
+        create: true
+        mode: "0640"
+        owner: root
+        group: root
+      when:
+        - ansible_facts.os_family == "Debian"
+      notify:
+        - Update GRUB
+
+    - name: Configure RedHat auditd GRUB cmdline
+      ansible.builtin.command:
+        cmd: grubby --update-kernel=ALL --args="{{ grub_audit_cmdline }} {{ grub_audit_backlog_cmdline }}"
+      register: grubby_update_kernel
+      changed_when: grubby_update_kernel.rc != 0
+      failed_when: grubby_update_kernel.rc != 0
+      when:
+        - ansible_facts.os_family == "RedHat"
+        - ansible_facts.virtualization_type not in ["container", "docker", "podman"]
+
+    - name: Configure auditd action_mail_acct
+      ansible.builtin.lineinfile:
+        regexp: ^action_mail_acct =
+        line: action_mail_acct = {{ auditd_action_mail_acct }}
+        dest: /etc/audit/auditd.conf
+        mode: "0640"
+        state: present
+        create: false
+
+    - name: Configure auditd admin_space_left_action
+      ansible.builtin.lineinfile:
+        regexp: ^admin_space_left_action =
+        line: admin_space_left_action = {{ auditd_admin_space_left_action }}
+        dest: /etc/audit/auditd.conf
+        mode: "0640"
+        state: present
+        create: false
+
+    - name: Configure auditd disk_error_action
+      ansible.builtin.lineinfile:
+        regexp: ^disk_error_action =
+        line: disk_error_action = {{ auditd_disk_error_action }}
+        dest: /etc/audit/auditd.conf
+        mode: "0640"
+        state: present
+        create: false
+
+    - name: Configure auditd disk_full_action
+      ansible.builtin.lineinfile:
+        regexp: ^disk_full_action =
+        line: disk_full_action = {{ auditd_disk_full_action }}
+        dest: /etc/audit/auditd.conf
+        mode: "0640"
+        state: present
+        create: false
+
+    - name: Configure auditd flush
+      ansible.builtin.lineinfile:
+        regexp: ^flush =
+        line: flush = {{ auditd_flush }}
+        dest: /etc/audit/auditd.conf
+        mode: "0640"
+        state: present
+        create: false
+
+    - name: Configure auditd max_log_file
+      ansible.builtin.lineinfile:
+        regexp: ^max_log_file =
+        line: max_log_file = {{ auditd_max_log_file }}
+        dest: /etc/audit/auditd.conf
+        mode: "0640"
+        state: present
+        create: false
+
+    - name: Configure auditd max_log_file_action
+      ansible.builtin.lineinfile:
+        regexp: ^max_log_file_action =
+        line: max_log_file_action = {{ auditd_max_log_file_action }}
+        dest: /etc/audit/auditd.conf
+        mode: "0640"
+        state: present
+        create: false
+
+    - name: Configure auditd num_logs
+      ansible.builtin.lineinfile:
+        regexp: ^num_logs =
+        line: num_logs = {{ auditd_num_logs }}
+        dest: /etc/audit/auditd.conf
+        mode: "0640"
+        state: present
+        create: false
+
+    - name: Configure auditd space_left
+      ansible.builtin.lineinfile:
+        regexp: ^space_left =
+        line: space_left = {{ auditd_space_left }}
+        dest: /etc/audit/auditd.conf
+        mode: "0640"
+        state: present
+        create: false
+
+    - name: Configure auditd space_left_action
+      ansible.builtin.lineinfile:
+        regexp: ^space_left_action =
+        line: space_left_action = {{ auditd_space_left_action }}
+        dest: /etc/audit/auditd.conf
+        mode: "0640"
+        state: present
+        create: false
+
+    - name: Configure auditd name_format
+      ansible.builtin.lineinfile:
+        regexp: ^name_format =
+        line: name_format = hostname
+        dest: /etc/audit/auditd.conf
+        mode: "0640"
+        state: present
+        create: false
+
+    - name: Enable auditd syslog plugin
+      ansible.builtin.lineinfile:
+        dest: /etc/audit/plugins.d/syslog.conf
+        regexp: ^active
+        line: active = yes
+        state: present
+        mode: "0640"
+        create: true
+
+    - name: Add auditd rules
+      ansible.builtin.template:
+        src: "{{ hardening_rules_template }}"
+        dest: /etc/audit/rules.d/hardening.rules
+        backup: true
+        mode: "0600"
+        owner: root
+        group: root
+      when:
+        - auditd_apply_audit_rules | bool
+      notify:
+        - Generate auditd rules
+        - Enable auditd

--- a/roles/auditd/templates/etc/audit/rules.d/hardening.rules.j2
+++ b/roles/auditd/templates/etc/audit/rules.d/hardening.rules.j2
@@ -1,0 +1,516 @@
+# Managed by Ansible role {{ ansible_role_name }}
+
+# Remove any existing rules
+-D
+
+# Buffer Size
+-b 8192
+
+# {{ 'Ignore errors' if auditd_ignore_errors else 'Report errors' }}
+{{ '-i' if auditd_ignore_errors else '-c' }}
+
+# Failure Mode
+-f {{ auditd_mode | int }}
+
+# File-related system calls and directory access
+-a always,exit -F arch=b32 -S creat,ftruncate,open,openat,truncate,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
+-a always,exit -F arch=b32 -S creat,ftruncate,open,openat,truncate,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
+-a always,exit -F arch=b32 -S open -F dir=/bin -F success=0 -F key=access
+-a always,exit -F arch=b32 -S open -F dir=/etc -F success=0 -F key=access
+-a always,exit -F arch=b32 -S open -F dir=/home -F success=0 -F key=access
+-a always,exit -F arch=b32 -S open -F dir=/root -F success=0 -F key=access
+-a always,exit -F arch=b32 -S open -F dir=/sbin -F success=0 -F key=access
+-a always,exit -F arch=b32 -S open -F dir=/srv -F success=0 -F key=access
+-a always,exit -F arch=b32 -S open -F dir=/tmp -F success=0 -F key=access
+-a always,exit -F arch=b32 -S open -F dir=/usr/bin -F success=0 -F key=access
+-a always,exit -F arch=b32 -S open -F dir=/usr/sbin -F success=0 -F key=access
+-a always,exit -F arch=b32 -S open -F dir=/var -F success=0 -F key=access
+-a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
+-a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
+-a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
+-a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
+-a always,exit -F arch=b64 -S creat,ftruncate,open,openat,truncate,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
+-a always,exit -F arch=b64 -S creat,ftruncate,open,openat,truncate,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
+-a always,exit -F arch=b64 -S open -F dir=/bin -F success=0 -F key=access
+-a always,exit -F arch=b64 -S open -F dir=/etc -F success=0 -F key=access
+-a always,exit -F arch=b64 -S open -F dir=/home -F success=0 -F key=access
+-a always,exit -F arch=b64 -S open -F dir=/root -F success=0 -F key=access
+-a always,exit -F arch=b64 -S open -F dir=/sbin -F success=0 -F key=access
+-a always,exit -F arch=b64 -S open -F dir=/srv -F success=0 -F key=access
+-a always,exit -F arch=b64 -S open -F dir=/tmp -F success=0 -F key=access
+-a always,exit -F arch=b64 -S open -F dir=/usr/bin -F success=0 -F key=access
+-a always,exit -F arch=b64 -S open -F dir=/usr/sbin -F success=0 -F key=access
+-a always,exit -F arch=b64 -S open -F dir=/var -F success=0 -F key=access
+-a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
+-a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
+-a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
+-a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
+
+# Various system calls by non-root users
+-a always,exit -F arch=b32 -C euid!=uid -F euid=0 -Fauid>=1000 -F auid!=unset -S execve -F key=actions
+-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat -F auid>=1000 -F auid!=unset -F key=actions
+-a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -F auid>=1000 -F auid!=unset -F key=actions
+-a always,exit -F arch=b32 -S creat,open,openat,truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=actions
+-a always,exit -F arch=b32 -S creat,open,openat,truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=actions
+-a always,exit -F arch=b32 -S fremovexattr,lremovexattr,removexattr -F auid>=1000 -F auid!=unset -F key=actions
+-a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F auid>=1000 -F auid!=unset -F key=actions
+-a always,exit -F arch=b64 -C euid!=uid -F euid=0 -Fauid>=1000 -F auid!=unset -S execve -F key=actions
+-a always,exit -F arch=b64 -S chmod,fchmod,fchmodat -F auid>=1000 -F auid!=unset -F key=actions
+-a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -F auid>=1000 -F auid!=unset -F key=actions
+-a always,exit -F arch=b64 -S creat,open,openat,truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=actions
+-a always,exit -F arch=b64 -S creat,open,openat,truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=actions
+-a always,exit -F arch=b64 -S fremovexattr,lremovexattr,removexattr -F auid>=1000 -F auid!=unset -F key=actions
+-a always,exit -F arch=b64 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F auid>=1000 -F auid!=unset -F key=actions
+
+# Access to su, sudo, and sudoers files
+-a always,exit -F path=/bin/su -F arch=b32 -F perm=x -F key=actions
+-a always,exit -F dir=/etc/sudoers.d/ -F arch=b32 -F perm=wa -F key=actions
+-a always,exit -F path=/etc/sudoers -F arch=b32 -F perm=wa -F key=actions
+-a always,exit -F path=/usr/bin/sudo -F arch=b32 -F perm=x -F key=actions
+-a always,exit -F path=/bin/su -F arch=b64 -F perm=x -F key=actions
+-a always,exit -F dir=/etc/sudoers.d/ -F arch=b64 -F perm=wa -F key=actions
+-a always,exit -F path=/etc/sudoers -F arch=b64 -F perm=wa -F key=actions
+-a always,exit -F path=/usr/bin/sudo -F arch=b64 -F perm=x -F key=actions
+
+# Actions by root in /home/ not owned by root
+-a always,exit -S all -F dir=/home/ -F uid=0 -C auid!=obj_uid -F key=admin-user-home
+
+# Access to AppArmor tools and configuration
+-a always,exit -F path=/sbin/apparmor_parser -F arch=b32 -F perm=x -F key=apparmor-tools
+-a always,exit -F path=/usr/sbin/aa-complain -F arch=b32 -F perm=x -F key=apparmor-tools
+-a always,exit -F path=/usr/sbin/aa-disable -F arch=b32 -F perm=x -F key=apparmor-tools
+-a always,exit -F path=/usr/sbin/aa-enforce -F arch=b32 -F perm=x -F key=apparmor-tools
+-a always,exit -F dir=/etc/apparmor.d -F arch=b32 -F perm=wa -F key=apparmor
+-a always,exit -F dir=/etc/apparmor -F arch=b32 -F perm=wa -F key=apparmor
+-a always,exit -F path=/sbin/apparmor_parser -F arch=b64 -F perm=x -F key=apparmor-tools
+-a always,exit -F path=/usr/sbin/aa-complain -F arch=b64 -F perm=x -F key=apparmor-tools
+-a always,exit -F path=/usr/sbin/aa-disable -F arch=b64 -F perm=x -F key=apparmor-tools
+-a always,exit -F path=/usr/sbin/aa-enforce -F arch=b64 -F perm=x -F key=apparmor-tools
+-a always,exit -F dir=/etc/apparmor.d -F arch=b64 -F perm=wa -F key=apparmor
+-a always,exit -F dir=/etc/apparmor -F arch=b64 -F perm=wa -F key=apparmor
+
+# Changes to audit configuration and tools
+-a always,exit -F path=/etc/audisp -F arch=b32 -F perm=wa -F key=audispconfig
+-a always,exit -F path=/etc/audit -F arch=b32 -F perm=wa -F key=auditconfig
+-a always,exit -F path=/etc/libaudit.conf -F arch=b32 -F perm=wa -F key=auditconfig
+-a always,exit -F path=/var/log/audit -F arch=b32 -F perm=rwxa -F key=auditlog
+-a always,exit -F path=/sbin/auditctl -F arch=b32 -F perm=x -F key=audittools
+-a always,exit -F path=/sbin/auditd -F arch=b32 -F perm=x -F key=audittools
+-a always,exit -F path=/etc/audisp -F arch=b64 -F perm=wa -F key=audispconfig
+-a always,exit -F path=/etc/audit -F arch=b64 -F perm=wa -F key=auditconfig
+-a always,exit -F path=/etc/libaudit.conf -F arch=b64 -F perm=wa -F key=auditconfig
+-a always,exit -F path=/var/log/audit -F arch=b64 -F perm=rwxa -F key=auditlog
+-a always,exit -F path=/sbin/auditctl -F arch=b64 -F perm=x -F key=audittools
+-a always,exit -F path=/sbin/auditd -F arch=b64 -F perm=x -F key=audittools
+
+# Network configuration changes
+-a always,exit -F arch=b32 -S sethostname,setdomainname -F key=audit_rules_networkconfig_modification
+-a always,exit -F arch=b64 -S sethostname,setdomainname -F key=audit_rules_networkconfig_modification
+-a always,exit -F path=/etc/hosts -F arch=b32 -F perm=wa -F key=audit_rules_networkconfig_modification
+-a always,exit -F path=/etc/issue.net -F arch=b32 -F perm=wa -F key=audit_rules_networkconfig_modification
+-a always,exit -F path=/etc/issue -F arch=b32 -F perm=wa -F key=audit_rules_networkconfig_modification
+-a always,exit -F path=/etc/sysconfig/network -F arch=b32 -F perm=wa -F key=audit_rules_networkconfig_modification
+-a always,exit -F path=/etc/hosts -F arch=b64 -F perm=wa -F key=audit_rules_networkconfig_modification
+-a always,exit -F path=/etc/issue.net -F arch=b64 -F perm=wa -F key=audit_rules_networkconfig_modification
+-a always,exit -F path=/etc/issue -F arch=b64 -F perm=wa -F key=audit_rules_networkconfig_modification
+-a always,exit -F path=/etc/sysconfig/network -F arch=b64 -F perm=wa -F key=audit_rules_networkconfig_modification
+
+# User/group file modifications
+-a always,exit -F path=/etc/group -F arch=b32 -F perm=wa -F key=audit_rules_usergroup_modification
+-a always,exit -F path=/etc/gshadow -F arch=b32 -F perm=wa -F key=audit_rules_usergroup_modification
+-a always,exit -F path=/etc/passwd -F arch=b32 -F perm=wa -F key=audit_rules_usergroup_modification
+-a always,exit -F path=/etc/security/opasswd -F arch=b32 -F perm=wa -F key=audit_rules_usergroup_modification
+-a always,exit -F path=/etc/shadow -F arch=b32 -F perm=wa -F key=audit_rules_usergroup_modification
+-a always,exit -F path=/etc/group -F arch=b64 -F perm=wa -F key=audit_rules_usergroup_modification
+-a always,exit -F path=/etc/gshadow -F arch=b64 -F perm=wa -F key=audit_rules_usergroup_modification
+-a always,exit -F path=/etc/passwd -F arch=b64 -F perm=wa -F key=audit_rules_usergroup_modification
+-a always,exit -F path=/etc/security/opasswd -F arch=b64 -F perm=wa -F key=audit_rules_usergroup_modification
+-a always,exit -F path=/etc/shadow -F arch=b64 -F perm=wa -F key=audit_rules_usergroup_modification
+
+# System time modifications
+-a always,exit -F arch=b32 -S adjtimex,settimeofday,stime -F key=audit_time_rules
+-a always,exit -F arch=b64 -S adjtimex,settimeofday -F key=audit_time_rules
+-a always,exit -F path=/etc/localtime -F arch=b32 -F perm=wa -F key=audit_time_rules
+-a always,exit -F path=/etc/localtime -F arch=b64 -F perm=wa -F key=audit_time_rules
+
+# Cron configuration modifications
+-a always,exit -F path=/etc/cron.allow -F arch=b32 -F perm=wa -F key=cron
+-a always,exit -F path=/etc/cron.daily -F arch=b32 -F perm=wa -F key=cron
+-a always,exit -F path=/etc/cron.deny -F arch=b32 -F perm=wa -F key=cron
+-a always,exit -F path=/etc/cron.d -F arch=b32 -F perm=wa -F key=cron
+-a always,exit -F path=/etc/cron.hourly -F arch=b32 -F perm=wa -F key=cron
+-a always,exit -F path=/etc/cron.monthly -F arch=b32 -F perm=wa -F key=cron
+-a always,exit -F path=/etc/crontab -F arch=b32 -F perm=wa -F key=cron
+-a always,exit -F path=/etc/cron.weekly -F arch=b32 -F perm=wa -F key=cron
+-a always,exit -F path=/var/spool/cron/crontabs -F arch=b32 -F perm=rwxa -F key=cron
+-a always,exit -F path=/etc/cron.allow -F arch=b64 -F perm=wa -F key=cron
+-a always,exit -F path=/etc/cron.daily -F arch=b64 -F perm=wa -F key=cron
+-a always,exit -F path=/etc/cron.deny -F arch=b64 -F perm=wa -F key=cron
+-a always,exit -F path=/etc/cron.d -F arch=b64 -F perm=wa -F key=cron
+-a always,exit -F path=/etc/cron.hourly -F arch=b64 -F perm=wa -F key=cron
+-a always,exit -F path=/etc/cron.monthly -F arch=b64 -F perm=wa -F key=cron
+-a always,exit -F path=/etc/crontab -F arch=b64 -F perm=wa -F key=cron
+-a always,exit -F path=/etc/cron.weekly -F arch=b64 -F perm=wa -F key=cron
+-a always,exit -F path=/var/spool/cron/crontabs -F arch=b64 -F perm=rwxa -F key=cron
+
+# File deletion and renaming by users
+-a always,exit -F arch=b32 -S rename,renameat,unlink,unlinkat -F auid>=1000 -F auid!=unset -F key=delete
+-a always,exit -F arch=b64 -S rename,renameat,unlink,unlinkat -F auid>=1000 -F auid!=unset -F key=delete
+
+# Group file modifications and group commands
+-a always,exit -F path=/etc/group -F arch=b32 -F perm=wa -F key=group-modification
+-a always,exit -F path=/etc/gshadow -F arch=b32 -F perm=wa -F key=group-modification
+-a always,exit -F path=/etc/passwd -F arch=b32 -F perm=wa -F key=group-modification
+-a always,exit -F path=/etc/security/opasswd -F arch=b32 -F perm=wa -F key=group-modification
+-a always,exit -F path=/etc/shadow -F arch=b32 -F perm=wa -F key=group-modification
+-a always,exit -F path=/usr/sbin/addgroup -F arch=b32 -F perm=x -F key=group-modification
+-a always,exit -F path=/usr/sbin/groupadd -F arch=b32 -F perm=x -F key=group-modification
+-a always,exit -F path=/usr/sbin/groupmod -F arch=b32 -F perm=x -F key=group-modification
+-a always,exit -F path=/etc/group -F arch=b64 -F perm=wa -F key=group-modification
+-a always,exit -F path=/etc/gshadow -F arch=b64 -F perm=wa -F key=group-modification
+-a always,exit -F path=/etc/passwd -F arch=b64 -F perm=wa -F key=group-modification
+-a always,exit -F path=/etc/security/opasswd -F arch=b64 -F perm=wa -F key=group-modification
+-a always,exit -F path=/etc/shadow -F arch=b64 -F perm=wa -F key=group-modification
+-a always,exit -F path=/usr/sbin/addgroup -F arch=b64 -F perm=x -F key=group-modification
+-a always,exit -F path=/usr/sbin/groupadd -F arch=b64 -F perm=x -F key=group-modification
+-a always,exit -F path=/usr/sbin/groupmod -F arch=b64 -F perm=x -F key=group-modification
+
+# Startup scripts
+-a always,exit -F dir=/etc/init.d -F arch=b32 -F perm=wa -F key=init
+-a always,exit -F path=/etc/init -F arch=b32 -F perm=wa -F key=init
+-a always,exit -F path=/etc/inittab -F arch=b32 -F perm=wa -F key=init
+-a always,exit -F dir=/etc/init.d -F arch=b64 -F perm=wa -F key=init
+-a always,exit -F path=/etc/init -F arch=b64 -F perm=wa -F key=init
+-a always,exit -F path=/etc/inittab -F arch=b64 -F perm=wa -F key=init
+
+# Library lookup paths
+-a always,exit -F dir=/etc/ld.so.conf.d/ -F arch=b32 -F perm=wa -F key=libpath
+-a always,exit -F path=/etc/ld.so.conf -F arch=b32 -F perm=wa -F key=libpath
+-a always,exit -F dir=/etc/ld.so.conf.d/ -F arch=b64 -F perm=wa -F key=libpath
+-a always,exit -F path=/etc/ld.so.conf -F arch=b64 -F perm=wa -F key=libpath
+
+# Local time
+-a always,exit -F path=/etc/localtime -F arch=b32 -F perm=wa -F key=localtime
+-a always,exit -F path=/etc/localtime -F arch=b64 -F perm=wa -F key=localtime
+
+# Login monitoring
+-a always,exit -F path=/etc/login.defs -F arch=b32 -F perm=wa -F key=login
+-a always,exit -F path=/etc/securetty -F arch=b32 -F perm=wa -F key=login
+-a always,exit -F path=/var/run/faillock -F arch=b32 -F perm=wa -F key=login
+-a always,exit -F path=/var/log/faillog -F arch=b32 -F perm=wa -F key=login
+-a always,exit -F path=/var/log/lastlog -F arch=b32 -F perm=wa -F key=login
+-a always,exit -F path=/var/log/tallylog -F arch=b32 -F perm=wa -F key=login
+-a always,exit -F path=/var/log/faillock -F arch=b32 -F perm=wa -F key=login
+-a always,exit -F path=/var/log/sudo.log -F arch=b32 -F perm=wa -F key=login
+-a always,exit -F path=/etc/login.defs -F arch=b64 -F perm=wa -F key=login
+-a always,exit -F path=/etc/securetty -F arch=b64 -F perm=wa -F key=login
+-a always,exit -F path=/var/run/faillock -F arch=b64 -F perm=wa -F key=login
+-a always,exit -F path=/var/log/faillog -F arch=b64 -F perm=wa -F key=login
+-a always,exit -F path=/var/log/lastlog -F arch=b64 -F perm=wa -F key=login
+-a always,exit -F path=/var/log/tallylog -F arch=b64 -F perm=wa -F key=login
+-a always,exit -F path=/var/log/faillock -F arch=b64 -F perm=wa -F key=login
+-a always,exit -F path=/var/log/sudo.log -F arch=b64 -F perm=wa -F key=login
+
+# SELinux configuration
+-a always,exit -F dir=/etc/selinux/ -F arch=b32 -F perm=wa -F key=MAC-policy
+-a always,exit -F dir=/usr/share/selinux/ -F arch=b32 -F perm=wa -F key=MAC-policy
+-a always,exit -F dir=/etc/selinux/ -F arch=b64 -F perm=wa -F key=MAC-policy
+-a always,exit -F dir=/usr/share/selinux/ -F arch=b64 -F perm=wa -F key=MAC-policy
+
+# Mail and Postfix
+-a always,exit -F path=/etc/aliases -F arch=b32 -F perm=wa -F key=mail
+-a always,exit -F path=/etc/postfix -F arch=b32 -F perm=wa -F key=mail
+-a always,exit -F path=/etc/aliases -F arch=b64 -F perm=wa -F key=mail
+-a always,exit -F path=/etc/postfix -F arch=b64 -F perm=wa -F key=mail
+
+# Kernel module configuration and tools
+-a always,exit -F path=/etc/modprobe.conf -F arch=b32 -F perm=wa -F key=modprobe
+-a always,exit -F dir=/etc/modprobe.d -F arch=b32 -F perm=wa -F key=modprobe
+-a always,exit -F path=/etc/modules -F arch=b32 -F perm=wa -F key=modprobe
+-a always,exit -F path=/etc/modprobe.conf -F arch=b64 -F perm=wa -F key=modprobe
+-a always,exit -F dir=/etc/modprobe.d -F arch=b64 -F perm=wa -F key=modprobe
+-a always,exit -F path=/etc/modules -F arch=b64 -F perm=wa -F key=modprobe
+-a always,exit -F arch=b32 -S create_module -F key=module-change
+-a always,exit -F arch=b32 -S create_module -F key=module-change
+-a always,exit -F arch=b64 -S create_module -F key=module-change
+-a always,exit -F arch=b32 -S delete_module,finit_module,init_module -F key=modules
+-a always,exit -F arch=b32 -S query_module -F auid>=1000 -F auid!=unset -F key=modules
+-a always,exit -F arch=b64 -S delete_module,finit_module,init_module -F key=modules
+-a always,exit -F arch=b64 -S query_module -F auid>=1000 -F auid!=unset -F key=modules
+-a always,exit -F path=/bin/kmod -F arch=b32 -F perm=x -F key=modules
+-a always,exit -F path=/sbin/insmod -F arch=b32 -F perm=x -F key=modules
+-a always,exit -F path=/sbin/modprobe -F arch=b32 -F perm=x -F key=modules
+-a always,exit -F path=/sbin/rmmod -F arch=b32 -F perm=x -F key=modules
+-a always,exit -F path=/usr/bin/kmod -F arch=b32 -F perm=x -F key=modules
+-a always,exit -F path=/usr/sbin/insmod -F arch=b32 -F perm=x -F key=modules
+-a always,exit -F path=/usr/sbin/modprobe -F arch=b32 -F perm=x -F key=modules
+-a always,exit -F path=/usr/sbin/rmmod -F arch=b32 -F perm=x -F key=modules
+-a always,exit -F path=/bin/kmod -F arch=b64 -F perm=x -F key=modules
+-a always,exit -F path=/sbin/insmod -F arch=b64 -F perm=x -F key=modules
+-a always,exit -F path=/sbin/modprobe -F arch=b64 -F perm=x -F key=modules
+-a always,exit -F path=/sbin/rmmod -F arch=b64 -F perm=x -F key=modules
+-a always,exit -F path=/usr/bin/kmod -F arch=b64 -F perm=x -F key=modules
+-a always,exit -F path=/usr/sbin/insmod -F arch=b64 -F perm=x -F key=modules
+-a always,exit -F path=/usr/sbin/modprobe -F arch=b64 -F perm=x -F key=modules
+-a always,exit -F path=/usr/sbin/rmmod -F arch=b64 -F perm=x -F key=modules
+
+# Mount events for accounts with UID => 1000
+-a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=unset -F key=mounts
+-a always,exit -F arch=b64 -S mount -F auid>=1000 -F auid!=unset -F key=mounts
+
+# PAM configuration files
+-a always,exit -F dir=/etc/pam.d -F arch=b32 -F perm=wa -F key=pam
+-a always,exit -F path=/etc/security/limits.conf -F arch=b32 -F perm=wa -F key=pam
+-a always,exit -F path=/etc/security/namespace.conf -F arch=b32 -F perm=wa -F key=pam
+-a always,exit -F path=/etc/security/namespace.init -F arch=b32 -F perm=wa -F key=pam
+-a always,exit -F path=/etc/security/pam_env.conf -F arch=b32 -F perm=wa -F key=pam
+-a always,exit -F dir=/etc/pam.d -F arch=b64 -F perm=wa -F key=pam
+-a always,exit -F path=/etc/security/limits.conf -F arch=b64 -F perm=wa -F key=pam
+-a always,exit -F path=/etc/security/namespace.conf -F arch=b64 -F perm=wa -F key=pam
+-a always,exit -F path=/etc/security/namespace.init -F arch=b64 -F perm=wa -F key=pam
+-a always,exit -F path=/etc/security/pam_env.conf -F arch=b64 -F perm=wa -F key=pam
+
+# Password modification
+-a always,exit -F path=/usr/bin/passwd -F arch=b32 -F perm=x -F key=passwd-modification
+-a always,exit -F path=/usr/bin/passwd -F arch=b64 -F perm=x -F key=passwd-modification
+
+#  Permission modifications by non-root users
+-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat -F auid>=1000 -F auid!=unset -F key=perm_mod
+-a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -F auid>=1000 -F auid!=unset -F key=perm_mod
+-a always,exit -F arch=b32 -S fremovexattr,fsetxattr,lremovexattr -F auid>=1000 -F auid!=unset -F key=perm_mod
+-a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=unset -F key=perm_mod
+-a always,exit -F arch=b64 -S chmod,fchmod,fchmodat -F auid>=1000 -F auid!=unset -F key=perm_mod
+-a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -F auid>=1000 -F auid!=unset -F key=perm_mod
+-a always,exit -F arch=b64 -S fremovexattr,lremovexattr,fsetxattr -F auid>=1000 -F auid!=unset -F key=perm_mod
+-a always,exit -F arch=b64 -S mount -F auid>=1000 -F auid!=unset -F key=perm_mod
+
+# Power management commands
+-a always,exit -F path=/sbin/halt -F arch=b32 -F perm=x -F key=power
+-a always,exit -F path=/sbin/poweroff -F arch=b32 -F perm=x -F key=power
+-a always,exit -F path=/sbin/reboot -F arch=b32 -F perm=x -F key=power
+-a always,exit -F path=/sbin/shutdown -F arch=b32 -F perm=x -F key=power
+-a always,exit -F path=/sbin/halt -F arch=b64 -F perm=x -F key=power
+-a always,exit -F path=/sbin/poweroff -F arch=b64 -F perm=x -F key=power
+-a always,exit -F path=/sbin/reboot -F arch=b64 -F perm=x -F key=power
+-a always,exit -F path=/sbin/shutdown -F arch=b64 -F perm=x -F key=power
+
+# Privileged command usage by non-root users
+-a always,exit -F path=/bin/fusermount -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/bin/mount -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/bin/ntfs-3g -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/bin/ping6 -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/bin/ping -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/bin/su -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/bin/umount -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/sbin/pam_extrausers_chkpwd -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/sbin/pam_timestamp_check -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/sbin/unix_chkpwd -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/at -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/bsd-write -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/cgclassify -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/cgexec -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/chacl -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/chage -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/chcon -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/chcon -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/chfn -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/chsh -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/crontab -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/dotlockfile -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/expiry -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/gpasswd -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/kmod -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/locate -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/mlocate -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/mount -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/newgidmap -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/newgrp -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/newuidmap -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/passwd -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/pkexec -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/screen -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/setfacl -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/ssh-agent -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/staprun -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/sudoedit -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/sudo -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/su -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/traceroute6.iputils -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/umount -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/userhelper -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/wall -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/write -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/lib/dbus-1.0/dbus-daemon-launch-helper -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/lib/eject/dmcrypt-get-device -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/libexec/abrt-action-install-debuginfo-to-abrt-cache -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/libexec/dbus-1/dbus-daemon-launch-helper -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/libexec/pt_chown -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/libexec/utempter/utempter -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/lib/openssh/ssh-keysign -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/lib/policykit-1/polkit-agent-helper-1 -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/lib/polkit-1/polkit-agent-helper-1 -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/lib/snapd/snap-confine -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/lib/x86_64-linux-gnu/utempter/utempter -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/fping6 -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/fping -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/grub2-set-bootflag -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/mount.cifs -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/mount.nfs -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/netreport -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/pam_extrausers_chkpwd -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/pam_timestamp_check -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/pam-tmpdir-helper -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/postdrop -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/postqueue -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/restorecon -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/semanage -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/setsebool -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/unix_chkpwd -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/userhelper -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/usermod -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/usernetct -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/usernetctl -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/vlock-main -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/bin/fusermount -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/bin/mount -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/bin/ntfs-3g -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/bin/ping6 -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/bin/ping -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/bin/su -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/bin/umount -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/sbin/pam_extrausers_chkpwd -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/sbin/pam_timestamp_check -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/sbin/unix_chkpwd -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/at -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/bsd-write -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/cgclassify -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/cgexec -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/chacl -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/chage -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/chcon -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/chcon -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/chfn -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/chsh -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/crontab -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/dotlockfile -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/expiry -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/gpasswd -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/kmod -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/locate -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/mlocate -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/mount -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/newgidmap -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/newgrp -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/newuidmap -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/passwd -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/pkexec -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/screen -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/setfacl -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/ssh-agent -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/staprun -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/sudoedit -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/sudo -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/su -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/traceroute6.iputils -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/umount -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/userhelper -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/wall -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/write -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/lib/dbus-1.0/dbus-daemon-launch-helper -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/lib/eject/dmcrypt-get-device -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/libexec/abrt-action-install-debuginfo-to-abrt-cache -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/libexec/dbus-1/dbus-daemon-launch-helper -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/libexec/pt_chown -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/libexec/utempter/utempter -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/lib/openssh/ssh-keysign -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/lib/policykit-1/polkit-agent-helper-1 -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/lib/polkit-1/polkit-agent-helper-1 -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/lib/snapd/snap-confine -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/lib/x86_64-linux-gnu/utempter/utempter -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/fping6 -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/fping -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/grub2-set-bootflag -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/mount.cifs -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/mount.nfs -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/netreport -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/pam_extrausers_chkpwd -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/pam_timestamp_check -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/pam-tmpdir-helper -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/postdrop -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/postqueue -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/restorecon -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/semanage -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/setsebool -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/unix_chkpwd -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/userhelper -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/usermod -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/usernetct -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/usernetctl -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/vlock-main -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+
+# Process and session initiation
+-a always,exit -F path=/var/log/btmp -F arch=b32 -F perm=wa -F key=session
+-a always,exit -F path=/var/log/wtmp -F arch=b32 -F perm=wa -F key=session
+-a always,exit -F path=/var/run/utmp -F arch=b32 -F perm=wa -F key=session
+-a always,exit -F path=/var/log/btmp -F arch=b64 -F perm=wa -F key=session
+-a always,exit -F path=/var/log/wtmp -F arch=b64 -F perm=wa -F key=session
+-a always,exit -F path=/var/run/utmp -F arch=b64 -F perm=wa -F key=session
+
+# Creation of special files
+-a always,exit -F arch=b32 -S mknod,mknodat -F key=specialfiles
+-a always,exit -F arch=b64 -S mknod,mknodat -F key=specialfiles
+
+# SSH configuration and tools
+-a always,exit -F dir=/etc/ssh/sshd_config.d/ -F arch=b32 -F perm=rwxa -F key=sshd
+-a always,exit -F path=/etc/ssh/sshd_config -F arch=b32 -F perm=rwxa -F key=sshd
+-a always,exit -F dir=/etc/ssh/sshd_config.d/ -F arch=b64 -F perm=rwxa -F key=sshd
+-a always,exit -F path=/etc/ssh/sshd_config -F arch=b64 -F perm=rwxa -F key=sshd
+
+# Sysctl configuration
+-a always,exit -F path=/etc/sysctl.conf -F arch=b32 -F perm=wa -F key=sysctl
+-a always,exit -F path=/etc/sysctl.conf -F arch=b64 -F perm=wa -F key=sysctl
+
+# Systemd configuration and tools
+-a always,exit -F path=/bin/journalctl -F arch=b32 -F perm=x -F key=systemd-tools
+-a always,exit -F path=/bin/systemctl -F arch=b32 -F perm=x -F key=systemd-tools
+-a always,exit -F dir=/etc/systemd -F arch=b32 -F perm=wa -F key=systemd
+-a always,exit -F dir=/lib/systemd -F arch=b32 -F perm=wa -F key=systemd
+-a always,exit -F path=/var/lib/systemd/credential.secret -F arch=b32 -F perm=wa -F key=systemd
+-a always,exit -F path=/bin/journalctl -F arch=b64 -F perm=x -F key=systemd-tools
+-a always,exit -F path=/bin/systemctl -F arch=b64 -F perm=x -F key=systemd-tools
+-a always,exit -F dir=/etc/systemd -F arch=b64 -F perm=wa -F key=systemd
+-a always,exit -F dir=/lib/systemd -F arch=b64 -F perm=wa -F key=systemd
+-a always,exit -F path=/var/lib/systemd/credential.secret -F arch=b64 -F perm=wa -F key=systemd
+
+# Time changes
+-a always,exit -F arch=b32 -S adjtimex,settimeofday,stime,clock_settime -F key=time-change
+-a always,exit -F arch=b64 -S adjtimex,settimeofday,clock_settime -F key=time-change
+-a always,exit -F path=/etc/localtime -F arch=b32 -F perm=wa -F key=time-change
+-a always,exit -F path=/etc/timezone -F arch=b32 -F perm=wa -F key=time-changezone
+-a always,exit -F path=/etc/localtime -F arch=b64 -F perm=wa -F key=time-change
+-a always,exit -F path=/etc/timezone -F arch=b64 -F perm=wa -F key=time-changezone
+
+# /tmp directories
+-a always,exit -F dir=/tmp -F arch=b32 -F perm=wxa -F key=tmp
+-a always,exit -F dir=/var/tmp -F arch=b32 -F perm=wxa -F key=tmp
+-a always,exit -F dir=/tmp -F arch=b64 -F perm=wxa -F key=tmp
+-a always,exit -F dir=/var/tmp -F arch=b64 -F perm=wxa -F key=tmp
+
+# User modifications
+-a always,exit -F arch=b32 -S execve -C euid!=uid -F auid!=unset -F key=user_emulation
+-a always,exit -F arch=b64 -S execve -C euid!=uid -F auid!=unset -F key=user_emulation
+-a always,exit -F arch=b32 -S execve -C uid!=euid -F euid=0 -k setuid
+-a always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -k setuid
+-a always,exit -F arch=b32 -S execve -C gid!=egid -F egid=0 -k setgid
+-a always,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -k setgid
+-a always,exit -F path=/usr/sbin/adduser -F arch=b32 -F perm=x -F key=user-modification
+-a always,exit -F path=/usr/sbin/useradd -F arch=b32 -F perm=x -F key=user-modification
+-a always,exit -F path=/usr/sbin/usermod -F arch=b32 -F perm=x -F key=user-modification
+-a always,exit -F path=/usr/sbin/adduser -F arch=b64 -F perm=x -F key=user-modification
+-a always,exit -F path=/usr/sbin/useradd -F arch=b64 -F perm=x -F key=user-modification
+-a always,exit -F path=/usr/sbin/usermod -F arch=b64 -F perm=x -F key=user-modification
+
+# Set the auditd flag
+-e {{ auditd_enable_flag }}

--- a/roles/auditd/templates/etc/audit/rules.d/hardening.rules.j2
+++ b/roles/auditd/templates/etc/audit/rules.d/hardening.rules.j2
@@ -231,7 +231,6 @@
 -a always,exit -F dir=/etc/modprobe.d -F arch=b64 -F perm=wa -F key=modprobe
 -a always,exit -F path=/etc/modules -F arch=b64 -F perm=wa -F key=modprobe
 -a always,exit -F arch=b32 -S create_module -F key=module-change
--a always,exit -F arch=b32 -S create_module -F key=module-change
 -a always,exit -F arch=b64 -S create_module -F key=module-change
 -a always,exit -F arch=b32 -S delete_module,finit_module,init_module -F key=modules
 -a always,exit -F arch=b32 -S query_module -F auid>=1000 -F auid!=unset -F key=modules
@@ -309,9 +308,8 @@
 -a always,exit -F path=/usr/bin/bsd-write -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/cgclassify -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/cgexec -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
--a always,exit -F path=/usr/bin/chacl -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/chacl -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/chage -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
--a always,exit -F path=/usr/bin/chcon -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/chcon -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/chfn -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/chsh -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
@@ -319,7 +317,7 @@
 -a always,exit -F path=/usr/bin/dotlockfile -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/expiry -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/gpasswd -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
--a always,exit -F path=/usr/bin/kmod -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/kmod -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/locate -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/mlocate -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/mount -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
@@ -329,7 +327,7 @@
 -a always,exit -F path=/usr/bin/passwd -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/pkexec -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/screen -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
--a always,exit -F path=/usr/bin/setfacl -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/setfacl -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/ssh-agent -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/staprun -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/sudoedit -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
@@ -368,8 +366,7 @@
 -a always,exit -F path=/usr/sbin/setsebool -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/sbin/unix_chkpwd -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/sbin/userhelper -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
--a always,exit -F path=/usr/sbin/usermod -F auid>=1000 -F auid!=unset -F key=privileged
--a always,exit -F path=/usr/sbin/usernetct -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/usermod -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/sbin/usernetctl -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/sbin/vlock-main -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/bin/fusermount -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
@@ -386,9 +383,8 @@
 -a always,exit -F path=/usr/bin/bsd-write -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/cgclassify -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/cgexec -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
--a always,exit -F path=/usr/bin/chacl -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/chacl -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/chage -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
--a always,exit -F path=/usr/bin/chcon -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/chcon -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/chfn -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/chsh -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
@@ -396,7 +392,7 @@
 -a always,exit -F path=/usr/bin/dotlockfile -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/expiry -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/gpasswd -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
--a always,exit -F path=/usr/bin/kmod -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/kmod -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/locate -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/mlocate -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/mount -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
@@ -406,7 +402,7 @@
 -a always,exit -F path=/usr/bin/passwd -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/pkexec -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/screen -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
--a always,exit -F path=/usr/bin/setfacl -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/bin/setfacl -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/ssh-agent -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/staprun -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/bin/sudoedit -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
@@ -445,8 +441,7 @@
 -a always,exit -F path=/usr/sbin/setsebool -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/sbin/unix_chkpwd -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/sbin/userhelper -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
--a always,exit -F path=/usr/sbin/usermod -F auid>=1000 -F auid!=unset -F key=privileged
--a always,exit -F path=/usr/sbin/usernetct -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+-a always,exit -F path=/usr/sbin/usermod -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/sbin/usernetctl -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 -a always,exit -F path=/usr/sbin/vlock-main -F arch=b64 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
 

--- a/roles/auditd/templates/etc/audit/rules.d/hardening.rules.j2
+++ b/roles/auditd/templates/etc/audit/rules.d/hardening.rules.j2
@@ -47,14 +47,14 @@
 -a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
 
 # Various system calls by non-root users
--a always,exit -F arch=b32 -C euid!=uid -F euid=0 -Fauid>=1000 -F auid!=unset -S execve -F key=actions
+-a always,exit -F arch=b32 -C euid!=uid -F euid=0 -F auid>=1000 -F auid!=unset -S execve -F key=actions
 -a always,exit -F arch=b32 -S chmod,fchmod,fchmodat -F auid>=1000 -F auid!=unset -F key=actions
 -a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -F auid>=1000 -F auid!=unset -F key=actions
 -a always,exit -F arch=b32 -S creat,open,openat,truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=actions
 -a always,exit -F arch=b32 -S creat,open,openat,truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=actions
 -a always,exit -F arch=b32 -S fremovexattr,lremovexattr,removexattr -F auid>=1000 -F auid!=unset -F key=actions
 -a always,exit -F arch=b32 -S setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F auid>=1000 -F auid!=unset -F key=actions
--a always,exit -F arch=b64 -C euid!=uid -F euid=0 -Fauid>=1000 -F auid!=unset -S execve -F key=actions
+-a always,exit -F arch=b64 -C euid!=uid -F euid=0 -F auid>=1000 -F auid!=unset -S execve -F key=actions
 -a always,exit -F arch=b64 -S chmod,fchmod,fchmodat -F auid>=1000 -F auid!=unset -F key=actions
 -a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -F auid>=1000 -F auid!=unset -F key=actions
 -a always,exit -F arch=b64 -S creat,open,openat,truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=actions


### PR DESCRIPTION
Privileged-command audit rules in `hardening.rules.j2` were missing `-F perm=x` and `-F arch=` filters, causing `auditctl`/`augenrules` to reject or silently skip them. Additional issues included duplicate rules and a binary path typo.

**Changes to `roles/auditd/templates/etc/audit/rules.d/hardening.rules.j2`:**

- **Missing filters fixed** — added `-F arch=b32`/`b64 -F perm=x` to `chacl`, `kmod`, `setfacl`, and `usermod` privileged rules for both architectures:
  ```
  # Before
  -a always,exit -F path=/usr/bin/setfacl -F auid>=1000 -F auid!=unset -F key=privileged

  # After
  -a always,exit -F path=/usr/bin/setfacl -F arch=b32 -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
  ```
- **Duplicate rules removed** — stripped redundant `chcon` entries (b32 + b64) that lacked `arch`/`perm` alongside correct versions that already existed; removed duplicate `create_module` b32 rule
- **Typo removed** — deleted `usernetct` entries (b32 + b64); correct `usernetctl` rules were already present