### PR TITLE
add selinux role

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Some roles require the following additional collections:
 
 | Collection | Minimum version | Required by |
 | --- | --- | --- |
-| `ansible.posix` | 2.2.0 | firewalld, mount, ufw |
+| `ansible.posix` | 2.2.0 | firewalld, mount, selinux, ufw |
 | `community.crypto` | 3.2.1 | ssh |
 | `community.general` | 13.0.1 | automatic_updates, disable_wireless, firewalld, ssh, ufw |
 
@@ -113,6 +113,7 @@ role. See each role's `README.md` for its variables and example usage.
 | [`resolvedconf`](roles/resolvedconf/README.md) | systemd-resolved configuration. | Debian, AlmaLinux/EL, Ubuntu |
 | [`root_access`](roles/root_access/README.md) | Limit root access using /etc/securetty, /etc/security/access.conf and masking debug-shell. | Debian, AlmaLinux/EL, Ubuntu |
 | [`schedulers`](roles/schedulers/README.md) | Configure scheduled command services. | Debian, AlmaLinux/EL, Ubuntu |
+| [`selinux`](roles/selinux/README.md) | SELinux installation and configuration. | AlmaLinux/EL |
 | [`ssh`](roles/ssh/README.md) | SSH installation and configuration. | Debian, AlmaLinux/EL, Ubuntu |
 | [`sudo`](roles/sudo/README.md) | SUDO configuration and hardening. | Debian, AlmaLinux/EL, Ubuntu |
 | [`sysctl`](roles/sysctl/README.md) | Applies kernel runtime hardening through sysctl: generic kernel, IPv4, and IPv6 network and memory-protection settings, with optional IPv6 disablement. | Debian, AlmaLinux/EL, Ubuntu |

--- a/extensions/molecule/resources/converge.yml
+++ b/extensions/molecule/resources/converge.yml
@@ -47,6 +47,7 @@
     - role: konstruktoid.hardening.ctrlaltdel
     - role: konstruktoid.hardening.auditd
     - role: konstruktoid.hardening.apparmor
+    - role: konstruktoid.hardening.selinux
     - role: konstruktoid.hardening.disable_wireless
     - role: konstruktoid.hardening.compilers
     - role: konstruktoid.hardening.umask

--- a/extensions/molecule/resources/verify.yml
+++ b/extensions/molecule/resources/verify.yml
@@ -153,6 +153,11 @@
       ansible.builtin.include_tasks:
         file: ../tests/verify_apparmor.yml
 
+    - name: Verify selinux role
+      ansible.builtin.include_tasks:
+        file: ../tests/verify_selinux.yml
+      when: ansible_facts.os_family == "RedHat"
+
     - name: Verify disable_wireless role
       ansible.builtin.include_tasks:
         file: ../tests/verify_disable_wireless.yml

--- a/extensions/molecule/tests/verify_selinux.yml
+++ b/extensions/molecule/tests/verify_selinux.yml
@@ -1,0 +1,35 @@
+---
+- name: SELinux block
+  when:
+    - ansible_facts.os_family == "RedHat"
+  block:
+    - name: Gather package facts
+      ansible.builtin.package_facts:
+        manager: auto
+
+    - name: Assert SELinux packages are installed
+      ansible.builtin.assert:
+        that:
+          - "'python3-libselinux' in ansible_facts.packages"
+          - "'selinux-policy-targeted' in ansible_facts.packages"
+
+    - name: Assert SELinux blocklisted packages are absent
+      ansible.builtin.assert:
+        that:
+          - "'setroubleshoot' not in ansible_facts.packages"
+          - "'mcstrans' not in ansible_facts.packages"
+
+    - name: Read /etc/selinux/config
+      ansible.builtin.slurp:
+        src: /etc/selinux/config
+      register: selinux_config_file
+      when:
+        - not ansible_facts.virtualization_type in ["container", "docker", "podman"]
+
+    - name: Assert /etc/selinux/config content
+      ansible.builtin.assert:
+        that:
+          - "'SELINUX=enforcing' in (selinux_config_file.content | b64decode)"
+          - "'SELINUXTYPE=targeted' in (selinux_config_file.content | b64decode)"
+      when:
+        - not ansible_facts.virtualization_type in ["container", "docker", "podman"]

--- a/extensions/molecule/tests/verify_selinux.yml
+++ b/extensions/molecule/tests/verify_selinux.yml
@@ -10,14 +10,14 @@
     - name: Assert SELinux packages are installed
       ansible.builtin.assert:
         that:
-          - "'python3-libselinux' in ansible_facts.packages"
-          - "'selinux-policy-targeted' in ansible_facts.packages"
+          - item in ansible_facts.packages
+      loop: "{{ selinux_packages }}"
 
     - name: Assert SELinux blocklisted packages are absent
       ansible.builtin.assert:
         that:
-          - "'setroubleshoot' not in ansible_facts.packages"
-          - "'mcstrans' not in ansible_facts.packages"
+          - item not in ansible_facts.packages
+      loop: "{{ selinux_packages_blocklist }}"
 
     - name: Read /etc/selinux/config
       ansible.builtin.slurp:

--- a/roles/selinux/README.md
+++ b/roles/selinux/README.md
@@ -24,7 +24,7 @@ Defined in `roles/selinux/defaults/main.yml`.
 | `selinux_packages_blocklist` | list, see below | Packages to remove, as they increase attack surface and are not required on a hardened, non-interactive host. |
 | `selinux_policy` | `"targeted"` | The SELinux policy to use. |
 | `selinux_state` | `"enforcing"` | The SELinux mode. One of `enforcing`, `permissive` or `disabled`. |
-| `selinux_update_kernel_param` | `true` | If True, also remove the `selinux=0` kernel command line argument using grubby. |
+| `selinux_update_kernel_param` | `true` | If True, also remove the `selinux=0` and `enforcing=0` kernel command line arguments using grubby. |
 
 `selinux_packages` default value:
 
@@ -49,9 +49,9 @@ setroubleshoot-server
 `tasks/main.yml` executes, in order, on AlmaLinux/EL hosts:
 
 1. Install SELinux packages
-2. Remove SELinux related packages
+2. Remove SELinux-related packages
 3. Configure SELinux state and policy
-4. Remove enforcing=0 from the kernel command line
+4. Remove selinux=0 and enforcing=0 from the kernel command line
 5. Notify if a reboot is required for the SELinux state to take effect
 
 The state, policy, and kernel-command-line steps are skipped inside

--- a/roles/selinux/README.md
+++ b/roles/selinux/README.md
@@ -1,0 +1,81 @@
+# selinux
+
+SELinux installation and configuration.
+
+## Requirements
+
+- Ansible-core >= 2.18
+- `ansible.posix` >= 2.2.0
+
+## Supported platforms
+
+| Platform | Versions |
+| --- | --- |
+| AlmaLinux / EL | 10 |
+
+## Role variables
+
+Defined in `roles/selinux/defaults/main.yml`.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `selinux_install_packages` | `true` | If True, install SELinux userspace utilities and the targeted policy. |
+| `selinux_packages` | list, see below | SELinux packages to install. |
+| `selinux_packages_blocklist` | list, see below | Packages to remove, as they increase attack surface and are not required on a hardened, non-interactive host. |
+| `selinux_policy` | `"targeted"` | The SELinux policy to use. |
+| `selinux_state` | `"enforcing"` | The SELinux mode. One of `enforcing`, `permissive` or `disabled`. |
+| `selinux_update_kernel_param` | `true` | If True, also remove the `selinux=0` kernel command line argument using grubby. |
+
+`selinux_packages` default value:
+
+```yaml
+libselinux-utils
+policycoreutils
+policycoreutils-python-utils
+python3-libselinux
+selinux-policy-targeted
+```
+
+`selinux_packages_blocklist` default value:
+
+```yaml
+mcstrans
+setroubleshoot
+setroubleshoot-server
+```
+
+## Tasks
+
+`tasks/main.yml` executes, in order, on AlmaLinux/EL hosts:
+
+1. Install SELinux packages
+2. Remove SELinux related packages
+3. Configure SELinux state and policy
+4. Remove enforcing=0 from the kernel command line
+5. Notify if a reboot is required for the SELinux state to take effect
+
+The state, policy, and kernel-command-line steps are skipped inside
+containers, since a container's kernel is shared with the host and
+`setenforce`/grubby changes there are either unavailable or meaningless.
+Package installation and removal still run in containers.
+
+Changing `selinux_state` to or from `disabled` requires a reboot before it
+takes effect; the role will not reboot the host itself, matching how the
+`kernel` and `apparmor` roles handle GRUB-only changes.
+
+## Example playbook
+
+```yaml
+- hosts: all
+  become: true
+  roles:
+    - konstruktoid.hardening.selinux
+```
+
+## Tags
+
+`almalinux`, `cis`, `disa`, `hardening`, `security`, `selinux`, `system`, `systemd`
+
+## License
+
+Apache-2.0

--- a/roles/selinux/defaults/main.yml
+++ b/roles/selinux/defaults/main.yml
@@ -1,0 +1,26 @@
+---
+# If True, install SELinux userspace utilities and the targeted policy.
+selinux_install_packages: true
+
+# SELinux packages to install.
+selinux_packages:
+  - "libselinux-utils"
+  - "policycoreutils"
+  - "policycoreutils-python-utils"
+  - "python3-libselinux"
+  - "selinux-policy-targeted"
+
+# Packages to remove, as they increase attack surface and are not required on a hardened, non-interactive host.
+selinux_packages_blocklist:
+  - "mcstrans"
+  - "setroubleshoot"
+  - "setroubleshoot-server"
+
+# The SELinux policy to use.
+selinux_policy: "targeted"
+
+# The SELinux mode. One of enforcing, permissive or disabled.
+selinux_state: "enforcing"
+
+# If True, also remove the "selinux=0" kernel command line argument using grubby.
+selinux_update_kernel_param: true

--- a/roles/selinux/defaults/main.yml
+++ b/roles/selinux/defaults/main.yml
@@ -22,5 +22,6 @@ selinux_policy: "targeted"
 # The SELinux mode. One of enforcing, permissive or disabled.
 selinux_state: "enforcing"
 
-# If True, also remove the "selinux=0" kernel command line argument using grubby.
+# If True, also remove the "selinux=0" and "enforcing=0" kernel command line
+# arguments using grubby.
 selinux_update_kernel_param: true

--- a/roles/selinux/meta/argument_specs.yml
+++ b/roles/selinux/meta/argument_specs.yml
@@ -42,6 +42,6 @@ argument_specs:
           - "permissive"
           - "disabled"
       selinux_update_kernel_param:
-        description: "If True, also remove the \"selinux=0\" kernel command line argument using grubby."
+        description: "If True, also remove the \"selinux=0\" and \"enforcing=0\" kernel command line arguments using grubby."
         type: "bool"
         default: true

--- a/roles/selinux/meta/argument_specs.yml
+++ b/roles/selinux/meta/argument_specs.yml
@@ -1,0 +1,47 @@
+---
+argument_specs:
+  main:
+    short_description: SELinux installation and configuration.
+    description:
+      - This role manages SELinux package installation, policy, and enforcement state.
+    author:
+      - "Thomas Sjögren (@konstruktoid)"
+    options:
+      selinux_install_packages:
+        description: "If True, install SELinux userspace utilities and the targeted policy."
+        type: "bool"
+        default: true
+      selinux_packages:
+        type: "list"
+        elements: "str"
+        default:
+          - "libselinux-utils"
+          - "policycoreutils"
+          - "policycoreutils-python-utils"
+          - "python3-libselinux"
+          - "selinux-policy-targeted"
+        description: "SELinux packages to install."
+      selinux_packages_blocklist:
+        type: "list"
+        elements: "str"
+        default:
+          - "mcstrans"
+          - "setroubleshoot"
+          - "setroubleshoot-server"
+        description: "Packages to remove, as they increase attack surface and are not required on a hardened, non-interactive host."
+      selinux_policy:
+        description: "The SELinux policy to use."
+        type: "str"
+        default: "targeted"
+      selinux_state:
+        description: "The SELinux mode. One of enforcing, permissive or disabled."
+        type: "str"
+        default: "enforcing"
+        choices:
+          - "enforcing"
+          - "permissive"
+          - "disabled"
+      selinux_update_kernel_param:
+        description: "If True, also remove the \"selinux=0\" kernel command line argument using grubby."
+        type: "bool"
+        default: true

--- a/roles/selinux/meta/main.yml
+++ b/roles/selinux/meta/main.yml
@@ -1,0 +1,20 @@
+---
+galaxy_info:
+  role_name: selinux
+  author: konstruktoid
+  description: SELinux installation and configuration.
+  license: apache
+  min_ansible_version: "2.18"
+  platforms:
+    - name: EL
+      versions:
+        - "10"
+  galaxy_tags:
+    - almalinux
+    - cis
+    - disa
+    - hardening
+    - security
+    - selinux
+    - system
+    - systemd

--- a/roles/selinux/tasks/main.yml
+++ b/roles/selinux/tasks/main.yml
@@ -25,9 +25,9 @@
       when:
         - ansible_facts.virtualization_type not in ["container", "docker", "podman"]
 
-    - name: Remove enforcing=0 from the kernel command line
+    - name: Remove selinux=0 and enforcing=0 from the kernel command line
       ansible.builtin.command:
-        cmd: grubby --update-kernel=ALL --remove-args="enforcing"
+        cmd: grubby --update-kernel=ALL --remove-args="selinux=0 enforcing=0"
       register: selinux_grubby_enforcing
       changed_when: false
       when:

--- a/roles/selinux/tasks/main.yml
+++ b/roles/selinux/tasks/main.yml
@@ -1,0 +1,44 @@
+---
+- name: Configure and enable SELinux
+  become: true
+  when:
+    - ansible_facts.os_family == "RedHat"
+  block:
+    - name: Install SELinux packages
+      ansible.builtin.package:
+        name: "{{ selinux_packages }}"
+        state: present
+      when:
+        - selinux_install_packages | bool
+
+    - name: Remove SELinux related packages
+      ansible.builtin.package:
+        name: "{{ selinux_packages_blocklist }}"
+        state: absent
+
+    - name: Configure SELinux state and policy
+      ansible.posix.selinux:
+        policy: "{{ selinux_policy }}"
+        state: "{{ selinux_state }}"
+        update_kernel_param: "{{ selinux_update_kernel_param }}"
+      register: selinux_config
+      when:
+        - ansible_facts.virtualization_type not in ["container", "docker", "podman"]
+
+    - name: Remove enforcing=0 from the kernel command line
+      ansible.builtin.command:
+        cmd: grubby --update-kernel=ALL --remove-args="enforcing"
+      register: selinux_grubby_enforcing
+      changed_when: false
+      when:
+        - ansible_facts.virtualization_type not in ["container", "docker", "podman"]
+
+    - name: Notify if a reboot is required for the SELinux state to take effect
+      ansible.builtin.debug:
+        msg: >-
+          A reboot is required for the SELinux state to change to
+          '{{ selinux_state }}'.
+      when:
+        - ansible_facts.virtualization_type not in ["container", "docker", "podman"]
+        - selinux_config is defined
+        - selinux_config.reboot_required | default(false)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new SELinux hardening role for Red Hat-based systems, applying the targeted policy in enforcing mode by default.
  * Installs and optionally removes selected SELinux-related packages, and updates kernel parameters when enabled.
  * Automatically notes when a reboot is required for the change to fully take effect.
* **Bug Fixes**
  * Added automated Molecule verification for required/blocked SELinux packages and configuration.
* **Documentation**
  * Updated role documentation and expanded the README with the new SELinux role requirement and supported platforms.
* **Tests**
  * Extended Molecule converge/verify playbooks to include SELinux checks on Red Hat systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->