### PR TITLE
add file_permissions role

Restrict the ownership and permissions of the account databases and of the
bootloader configuration files. Files that do not exist on the target host
are skipped, and bootloader files are only tightened when they are group or
other accessible, so that the 0400 grub-mkconfig output stays untouched.


Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Unreleased
+
+- Add `file_permissions` role, restricting the ownership and permissions of the account
+  databases (`/etc/passwd`, `/etc/shadow`, `/etc/group`, `/etc/gshadow`, their backup files
+  and `/etc/security/opasswd`) and of the bootloader configuration files.
+
 ## 0.2.0 (2026-07-23)
 
 - Add `firewalld` role.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Ansible collection for hardening systemd-based Linux servers: AlmaLinux, Debian,
 and Ubuntu. It applies CIS Benchmark- and DISA STIG-aligned security controls
-through 40 independent, single-purpose roles covering SSH, sudo, PAM,
+through 43 independent, single-purpose roles covering SSH, sudo, PAM,
 auditd, sysctl, firewalling, mounts, and kernel modules, among other hardening
 domains.
 
@@ -92,6 +92,7 @@ role. See each role's `README.md` for its variables and example usage.
 | [`delete_users`](roles/delete_users/README.md) | Delete listed users. | Debian, AlmaLinux/EL, Ubuntu |
 | [`disable_ipv6`](roles/disable_ipv6/README.md) | Disable IPv6 by configuring the `net.ipv6.conf.*.disable_ipv6` sysctl keys and the GRUB kernel command line. | Debian, AlmaLinux/EL, Ubuntu |
 | [`disable_wireless`](roles/disable_wireless/README.md) | Disable wireless interfaces and wireless kernel modules on AlmaLinux, Debian, and Ubuntu systems. | Debian, AlmaLinux/EL, Ubuntu |
+| [`file_permissions`](roles/file_permissions/README.md) | Restrict the ownership and permissions of the account databases and of the bootloader configuration files. | Debian, AlmaLinux/EL, Ubuntu |
 | [`firewalld`](roles/firewalld/README.md) | An Ansible role to manage firewalld default-deny zone rules. | AlmaLinux/EL |
 | [`issue`](roles/issue/README.md) | Role to update /etc/issue and /etc/motd files using Jinja2 templates. | Debian, AlmaLinux/EL, Ubuntu |
 | [`journald`](roles/journald/README.md) | Configures systemd-journald storage, rotation, and file permissions; installs and configures rsyslog and logrotate for log forwarding and rotation; disables systemd-journal-remote. | Debian, AlmaLinux/EL, Ubuntu |

--- a/extensions/molecule/resources/converge.yml
+++ b/extensions/molecule/resources/converge.yml
@@ -60,3 +60,4 @@
     - role: konstruktoid.hardening.kernel_modules
     - role: konstruktoid.hardening.aide
     - role: konstruktoid.hardening.password_management
+    - role: konstruktoid.hardening.file_permissions

--- a/extensions/molecule/resources/verify.yml
+++ b/extensions/molecule/resources/verify.yml
@@ -205,3 +205,7 @@
     - name: Verify password_management role
       ansible.builtin.include_tasks:
         file: ../tests/verify_password_management.yml
+
+    - name: Verify file_permissions role
+      ansible.builtin.include_tasks:
+        file: ../tests/verify_file_permissions.yml

--- a/extensions/molecule/tests/verify_file_permissions.yml
+++ b/extensions/molecule/tests/verify_file_permissions.yml
@@ -1,0 +1,55 @@
+---
+- name: Verify account database ownership and permissions
+  become: true
+  block:
+    - name: Stat account databases
+      ansible.builtin.stat:
+        path: "{{ item.path }}"
+        get_attributes: false
+        get_checksum: false
+        get_mime: false
+      loop: "{{ file_permissions_account_databases }}"
+      loop_control:
+        label: "{{ item.path }}"
+      register: verify_account_databases
+
+    - name: Assert account database ownership and permissions
+      ansible.builtin.assert:
+        that:
+          - item.stat.mode == item.item.mode
+          - item.stat.pw_name == item.item.owner
+          - item.stat.gr_name == item.item.group
+        success_msg: >-
+          {{ item.item.path }} has the expected ownership and permissions:
+          {{ item.stat.mode }} {{ item.stat.pw_name }}:{{ item.stat.gr_name }}
+        fail_msg: >-
+          {{ item.item.path }} ownership or permissions are incorrect:
+          {{ item.stat.mode }} {{ item.stat.pw_name }}:{{ item.stat.gr_name }},
+          expected {{ item.item.mode }} {{ item.item.owner }}:{{ item.item.group }}
+      loop: "{{ verify_account_databases.results | selectattr('stat.exists') | list }}"
+      loop_control:
+        label: "{{ item.item.path }}"
+
+- name: Verify bootloader configuration permissions
+  become: true
+  block:
+    - name: Stat bootloader configuration
+      ansible.builtin.stat:
+        path: "{{ item }}"
+        get_attributes: false
+        get_checksum: false
+        get_mime: false
+      loop: "{{ file_permissions_bootloader_files }}"
+      register: verify_bootloader_files
+
+    - name: Assert bootloader configuration is not group or other accessible
+      ansible.builtin.assert:
+        that:
+          - item.stat.mode is search("00$")
+        success_msg: >-
+          {{ item.item }} is not group or other accessible: {{ item.stat.mode }}
+        fail_msg: >-
+          {{ item.item }} is group or other accessible: {{ item.stat.mode }}
+      loop: "{{ verify_bootloader_files.results | selectattr('stat.exists') | list }}"
+      loop_control:
+        label: "{{ item.item }}"

--- a/extensions/molecule/tests/verify_file_permissions.yml
+++ b/extensions/molecule/tests/verify_file_permissions.yml
@@ -42,14 +42,18 @@
       loop: "{{ file_permissions_bootloader_files }}"
       register: verify_bootloader_files
 
-    - name: Assert bootloader configuration is not group or other accessible
+    - name: Assert bootloader configuration is root owned and not group or other accessible
       ansible.builtin.assert:
         that:
           - item.stat.mode is search("00$")
+          - item.stat.pw_name == "root"
+          - item.stat.gr_name == "root"
         success_msg: >-
-          {{ item.item }} is not group or other accessible: {{ item.stat.mode }}
+          {{ item.item }} is root owned and not group or other accessible:
+          {{ item.stat.mode }} {{ item.stat.pw_name }}:{{ item.stat.gr_name }}
         fail_msg: >-
-          {{ item.item }} is group or other accessible: {{ item.stat.mode }}
+          {{ item.item }} is group or other accessible, or not root owned:
+          {{ item.stat.mode }} {{ item.stat.pw_name }}:{{ item.stat.gr_name }}
       loop: "{{ verify_bootloader_files.results | selectattr('stat.exists') | list }}"
       loop_control:
         label: "{{ item.item }}"

--- a/roles/file_permissions/README.md
+++ b/roles/file_permissions/README.md
@@ -1,0 +1,71 @@
+# file_permissions
+
+Ensure account database and bootloader configuration permissions.
+
+The role restricts the ownership and permissions of the account databases and of
+the bootloader configuration files, so that credentials and boot parameters are
+not exposed to unprivileged users. Files that do not exist on the target host are
+skipped.
+
+Bootloader files are only tightened when they are readable or writable by group
+or other. `grub-mkconfig` writes `/boot/grub/grub.cfg` with mode `0400`, and
+unconditionally rewriting it to `file_permissions_bootloader_mode` would make the
+role report a change on every run. Files on the `vfat` EFI system partition are
+not managed at all, since that file system has no Unix permissions.
+
+## Requirements
+
+- Ansible-core >= 2.18
+
+## Supported platforms
+
+| Platform | Versions |
+| --- | --- |
+| Debian | trixie |
+| EL | 10 |
+| Ubuntu | resolute |
+
+## Role variables
+
+Defined in `roles/file_permissions/defaults/main.yml`.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `file_permissions_account_databases` | See `defaults/main.yml` | The account databases to manage, and the ownership and permissions to apply to them. |
+| `file_permissions_bootloader` | `true` | Manage the permissions of the bootloader configuration files listed in `file_permissions_bootloader_files`. |
+| `file_permissions_bootloader_files` | `["/boot/grub/grub.cfg", "/boot/grub/grubenv", "/boot/grub/user.cfg", "/boot/grub2/grub.cfg", "/boot/grub2/grubenv", "/boot/grub2/user.cfg", "/boot/loader/loader.conf"]` | Bootloader configuration files that should not be readable or writable by group or other. |
+| `file_permissions_bootloader_mode` | `"0600"` | The file mode applied to a `file_permissions_bootloader_files` entry that is readable or writable by group or other. |
+| `file_permissions_opasswd_mode` | `"0600"` | File mode of `/etc/security/opasswd` and `/etc/security/opasswd.old`, the `pam_pwhistory` password history databases. |
+| `file_permissions_passwd` | `true` | Manage the ownership and permissions of the `file_permissions_account_databases` files. |
+| `file_permissions_passwd_backup_mode` | `"0600"` | File mode of the `/etc/passwd-` and `/etc/group-` backup files. |
+| `file_permissions_passwd_mode` | `"0644"` | File mode of the world readable account databases, `/etc/passwd` and `/etc/group`. |
+| `file_permissions_shadow_group` | `"shadow"` on the Debian family, `"root"` otherwise | Owner group of `/etc/shadow`, `/etc/shadow-`, `/etc/gshadow` and `/etc/gshadow-`. |
+| `file_permissions_shadow_mode` | `"0640"` on the Debian family, `"0000"` otherwise | File mode of `/etc/shadow`, `/etc/shadow-`, `/etc/gshadow` and `/etc/gshadow-`. |
+
+## Tasks
+
+`tasks/main.yml` executes, in order:
+
+1. Configure account database ownership and permissions
+2. Stat account databases
+3. Set account database ownership and permissions
+4. Restrict bootloader configuration permissions
+5. Stat bootloader configuration
+6. Set bootloader configuration permissions
+
+## Example playbook
+
+```yaml
+- hosts: all
+  become: true
+  roles:
+    - konstruktoid.hardening.file_permissions
+```
+
+## Tags
+
+`almalinux`, `cis`, `debian`, `disa`, `hardening`, `permissions`, `security`, `system`, `systemd`, `ubuntu`
+
+## License
+
+Apache-2.0

--- a/roles/file_permissions/README.md
+++ b/roles/file_permissions/README.md
@@ -7,11 +7,14 @@ the bootloader configuration files, so that credentials and boot parameters are
 not exposed to unprivileged users. Files that do not exist on the target host are
 skipped.
 
-Bootloader files are only tightened when they are readable or writable by group
-or other. `grub-mkconfig` writes `/boot/grub/grub.cfg` with mode `0400`, and
-unconditionally rewriting it to `file_permissions_bootloader_mode` would make the
-role report a change on every run. Files on the `vfat` EFI system partition are
-not managed at all, since that file system has no Unix permissions.
+Bootloader files are managed when they are readable or writable by group or
+other, or when they are not owned by `root:root`. A file that is already
+inaccessible to group and other keeps its mode and only has its ownership
+corrected: `grub-mkconfig` writes `/boot/grub/grub.cfg` with mode `0400`, and
+rewriting it to `file_permissions_bootloader_mode` would both widen the mode and
+make the role report a change on every run. Files on the `vfat` EFI system
+partition are not managed at all, since that file system has no Unix
+permissions.
 
 ## Requirements
 
@@ -32,8 +35,8 @@ Defined in `roles/file_permissions/defaults/main.yml`.
 | Variable | Default | Description |
 | --- | --- | --- |
 | `file_permissions_account_databases` | See `defaults/main.yml` | The account databases to manage, and the ownership and permissions to apply to them. |
-| `file_permissions_bootloader` | `true` | Manage the permissions of the bootloader configuration files listed in `file_permissions_bootloader_files`. |
-| `file_permissions_bootloader_files` | `["/boot/grub/grub.cfg", "/boot/grub/grubenv", "/boot/grub/user.cfg", "/boot/grub2/grub.cfg", "/boot/grub2/grubenv", "/boot/grub2/user.cfg", "/boot/loader/loader.conf"]` | Bootloader configuration files that should not be readable or writable by group or other. |
+| `file_permissions_bootloader` | `true` | Manage the ownership and permissions of the bootloader configuration files listed in `file_permissions_bootloader_files`. |
+| `file_permissions_bootloader_files` | `["/boot/grub/grub.cfg", "/boot/grub/grubenv", "/boot/grub/user.cfg", "/boot/grub2/grub.cfg", "/boot/grub2/grubenv", "/boot/grub2/user.cfg", "/boot/loader/loader.conf"]` | Bootloader configuration files that should be owned by `root:root` and not readable or writable by group or other. |
 | `file_permissions_bootloader_mode` | `"0600"` | The file mode applied to a `file_permissions_bootloader_files` entry that is readable or writable by group or other. |
 | `file_permissions_opasswd_mode` | `"0600"` | File mode of `/etc/security/opasswd` and `/etc/security/opasswd.old`, the `pam_pwhistory` password history databases. |
 | `file_permissions_passwd` | `true` | Manage the ownership and permissions of the `file_permissions_account_databases` files. |
@@ -51,7 +54,7 @@ Defined in `roles/file_permissions/defaults/main.yml`.
 3. Set account database ownership and permissions
 4. Restrict bootloader configuration permissions
 5. Stat bootloader configuration
-6. Set bootloader configuration permissions
+6. Set bootloader configuration ownership and permissions
 
 ## Example playbook
 

--- a/roles/file_permissions/defaults/main.yml
+++ b/roles/file_permissions/defaults/main.yml
@@ -1,0 +1,90 @@
+---
+# The account databases to manage, and the ownership and permissions to apply
+# to them. Files that do not exist on the target host are skipped.
+file_permissions_account_databases:
+  - path: "/etc/group"
+    owner: "root"
+    group: "root"
+    mode: "{{ file_permissions_passwd_mode }}"
+  - path: "/etc/group-"
+    owner: "root"
+    group: "root"
+    mode: "{{ file_permissions_passwd_backup_mode }}"
+  - path: "/etc/gshadow"
+    owner: "root"
+    group: "{{ file_permissions_shadow_group }}"
+    mode: "{{ file_permissions_shadow_mode }}"
+  - path: "/etc/gshadow-"
+    owner: "root"
+    group: "{{ file_permissions_shadow_group }}"
+    mode: "{{ file_permissions_shadow_mode }}"
+  - path: "/etc/passwd"
+    owner: "root"
+    group: "root"
+    mode: "{{ file_permissions_passwd_mode }}"
+  - path: "/etc/passwd-"
+    owner: "root"
+    group: "root"
+    mode: "{{ file_permissions_passwd_backup_mode }}"
+  - path: "/etc/security/opasswd"
+    owner: "root"
+    group: "root"
+    mode: "{{ file_permissions_opasswd_mode }}"
+  - path: "/etc/security/opasswd.old"
+    owner: "root"
+    group: "root"
+    mode: "{{ file_permissions_opasswd_mode }}"
+  - path: "/etc/shadow"
+    owner: "root"
+    group: "{{ file_permissions_shadow_group }}"
+    mode: "{{ file_permissions_shadow_mode }}"
+  - path: "/etc/shadow-"
+    owner: "root"
+    group: "{{ file_permissions_shadow_group }}"
+    mode: "{{ file_permissions_shadow_mode }}"
+
+# Manage the permissions of the bootloader configuration files listed in
+# C(file_permissions_bootloader_files).
+file_permissions_bootloader: true
+
+# Bootloader configuration files that should not be readable or writable by
+# group or other. Files residing on the C(vfat) EFI system partition are
+# deliberately excluded since that file system has no Unix permissions.
+file_permissions_bootloader_files:
+  - "/boot/grub/grub.cfg"
+  - "/boot/grub/grubenv"
+  - "/boot/grub/user.cfg"
+  - "/boot/grub2/grub.cfg"
+  - "/boot/grub2/grubenv"
+  - "/boot/grub2/user.cfg"
+  - "/boot/loader/loader.conf"
+
+# The file mode applied to a C(file_permissions_bootloader_files) entry that is
+# readable or writable by group or other. Files that already have no group and
+# other permission bits are left alone, since C(grub-mkconfig) writes C(0400)
+# and rewriting those would make the role non-idempotent.
+file_permissions_bootloader_mode: "0600"
+
+# File mode of C(/etc/security/opasswd) and C(/etc/security/opasswd.old), the
+# C(pam_pwhistory) password history databases.
+file_permissions_opasswd_mode: "0600"
+
+# Manage the ownership and permissions of the
+# C(file_permissions_account_databases) files.
+file_permissions_passwd: true
+
+# File mode of the C(/etc/passwd-) and C(/etc/group-) backup files.
+file_permissions_passwd_backup_mode: "0600"
+
+# File mode of the world readable account databases, C(/etc/passwd) and
+# C(/etc/group).
+file_permissions_passwd_mode: "0644"
+
+# Owner group of C(/etc/shadow), C(/etc/shadow-), C(/etc/gshadow) and
+# C(/etc/gshadow-). Debian family systems use a dedicated C(shadow) group so
+# that setgid helpers, C(unix_chkpwd) for example, can read the file.
+file_permissions_shadow_group: "{{ 'shadow' if ansible_facts.os_family == 'Debian' else 'root' }}"
+
+# File mode of C(/etc/shadow), C(/etc/shadow-), C(/etc/gshadow) and
+# C(/etc/gshadow-).
+file_permissions_shadow_mode: "{{ '0640' if ansible_facts.os_family == 'Debian' else '0000' }}"

--- a/roles/file_permissions/defaults/main.yml
+++ b/roles/file_permissions/defaults/main.yml
@@ -43,13 +43,14 @@ file_permissions_account_databases:
     group: "{{ file_permissions_shadow_group }}"
     mode: "{{ file_permissions_shadow_mode }}"
 
-# Manage the permissions of the bootloader configuration files listed in
-# C(file_permissions_bootloader_files).
+# Manage the ownership and permissions of the bootloader configuration files
+# listed in C(file_permissions_bootloader_files).
 file_permissions_bootloader: true
 
-# Bootloader configuration files that should not be readable or writable by
-# group or other. Files residing on the C(vfat) EFI system partition are
-# deliberately excluded since that file system has no Unix permissions.
+# Bootloader configuration files that should be owned by C(root:root) and not
+# readable or writable by group or other. Files residing on the C(vfat) EFI
+# system partition are deliberately excluded since that file system has no Unix
+# permissions.
 file_permissions_bootloader_files:
   - "/boot/grub/grub.cfg"
   - "/boot/grub/grubenv"
@@ -61,8 +62,9 @@ file_permissions_bootloader_files:
 
 # The file mode applied to a C(file_permissions_bootloader_files) entry that is
 # readable or writable by group or other. Files that already have no group and
-# other permission bits are left alone, since C(grub-mkconfig) writes C(0400)
-# and rewriting those would make the role non-idempotent.
+# other permission bits keep their mode, since C(grub-mkconfig) writes C(0400)
+# and rewriting those would both widen the mode and make the role
+# non-idempotent. Ownership is set to C(root:root) regardless of the mode.
 file_permissions_bootloader_mode: "0600"
 
 # File mode of C(/etc/security/opasswd) and C(/etc/security/opasswd.old), the

--- a/roles/file_permissions/meta/argument_specs.yml
+++ b/roles/file_permissions/meta/argument_specs.yml
@@ -1,0 +1,84 @@
+---
+argument_specs:
+  main:
+    short_description: Account database and bootloader configuration permissions.
+    description:
+      - This role restricts the ownership and permissions of the account databases and of the bootloader configuration files.
+      - Credentials and boot parameters are thereby not exposed to unprivileged users.
+      - Files that do not exist on the target host are skipped.
+    author:
+      - konstruktoid
+    options:
+      file_permissions_account_databases:
+        description: "The account databases to manage, and the ownership and permissions to apply to them."
+        type: "list"
+        elements: "dict"
+        options:
+          path:
+            description: "Absolute path of the account database."
+            type: "str"
+            required: true
+          owner:
+            description: "Owner of the account database."
+            type: "str"
+            required: true
+          group:
+            description: "Owner group of the account database."
+            type: "str"
+            required: true
+          mode:
+            description: "File mode of the account database."
+            type: "str"
+            required: true
+      file_permissions_bootloader:
+        description: "Manage the permissions of the bootloader configuration files listed in C(file_permissions_bootloader_files)."
+        type: "bool"
+        default: true
+      file_permissions_bootloader_files:
+        description:
+          - "Bootloader configuration files that should not be readable or writable by group or other."
+          - "Files residing on the C(vfat) EFI system partition are deliberately excluded since that file system has no Unix permissions."
+        type: "list"
+        elements: "str"
+        default:
+          - "/boot/grub/grub.cfg"
+          - "/boot/grub/grubenv"
+          - "/boot/grub/user.cfg"
+          - "/boot/grub2/grub.cfg"
+          - "/boot/grub2/grubenv"
+          - "/boot/grub2/user.cfg"
+          - "/boot/loader/loader.conf"
+      file_permissions_bootloader_mode:
+        description:
+          - "The file mode applied to a C(file_permissions_bootloader_files) entry that is readable or writable by group or other."
+          - "Files that already have no group and other permission bits are left alone."
+          - "C(grub-mkconfig) writes C(0400), and rewriting those files would make the role non-idempotent."
+        type: "str"
+        default: "0600"
+      file_permissions_opasswd_mode:
+        description: "File mode of C(/etc/security/opasswd) and C(/etc/security/opasswd.old), the C(pam_pwhistory) password history databases."
+        type: "str"
+        default: "0600"
+      file_permissions_passwd:
+        description: "Manage the ownership and permissions of the C(file_permissions_account_databases) files."
+        type: "bool"
+        default: true
+      file_permissions_passwd_backup_mode:
+        description: "File mode of the C(/etc/passwd-) and C(/etc/group-) backup files."
+        type: "str"
+        default: "0600"
+      file_permissions_passwd_mode:
+        description: "File mode of the world readable account databases, C(/etc/passwd) and C(/etc/group)."
+        type: "str"
+        default: "0644"
+      file_permissions_shadow_group:
+        description:
+          - "Owner group of C(/etc/shadow), C(/etc/shadow-), C(/etc/gshadow) and C(/etc/gshadow-)."
+          - "Debian family systems use a dedicated C(shadow) group so that setgid helpers, C(unix_chkpwd) for example, can read the file."
+          - "Defaults to C(shadow) on the Debian family and to C(root) otherwise."
+        type: "str"
+      file_permissions_shadow_mode:
+        description:
+          - "File mode of C(/etc/shadow), C(/etc/shadow-), C(/etc/gshadow) and C(/etc/gshadow-)."
+          - "Defaults to C(0640) on the Debian family and to C(0000) otherwise."
+        type: "str"

--- a/roles/file_permissions/meta/argument_specs.yml
+++ b/roles/file_permissions/meta/argument_specs.yml
@@ -1,13 +1,13 @@
 ---
 argument_specs:
   main:
-    short_description: Account database and bootloader configuration permissions.
+    short_description: "Account database and bootloader configuration permissions."
     description:
-      - This role restricts the ownership and permissions of the account databases and of the bootloader configuration files.
-      - Credentials and boot parameters are thereby not exposed to unprivileged users.
-      - Files that do not exist on the target host are skipped.
+      - "This role restricts the ownership and permissions of the account databases and of the bootloader configuration files."
+      - "Credentials and boot parameters are thereby not exposed to unprivileged users."
+      - "Files that do not exist on the target host are skipped."
     author:
-      - konstruktoid
+      - "Thomas Sjögren (@konstruktoid)"
     options:
       file_permissions_account_databases:
         description: "The account databases to manage, and the ownership and permissions to apply to them."
@@ -31,12 +31,12 @@ argument_specs:
             type: "str"
             required: true
       file_permissions_bootloader:
-        description: "Manage the permissions of the bootloader configuration files listed in C(file_permissions_bootloader_files)."
+        description: "Manage the ownership and permissions of the bootloader configuration files listed in C(file_permissions_bootloader_files)."
         type: "bool"
         default: true
       file_permissions_bootloader_files:
         description:
-          - "Bootloader configuration files that should not be readable or writable by group or other."
+          - "Bootloader configuration files that should be owned by C(root:root) and not readable or writable by group or other."
           - "Files residing on the C(vfat) EFI system partition are deliberately excluded since that file system has no Unix permissions."
         type: "list"
         elements: "str"
@@ -51,8 +51,8 @@ argument_specs:
       file_permissions_bootloader_mode:
         description:
           - "The file mode applied to a C(file_permissions_bootloader_files) entry that is readable or writable by group or other."
-          - "Files that already have no group and other permission bits are left alone."
-          - "C(grub-mkconfig) writes C(0400), and rewriting those files would make the role non-idempotent."
+          - "Files that already have no group and other permission bits keep their mode, their ownership is still set to C(root:root)."
+          - "C(grub-mkconfig) writes C(0400), and rewriting those files would both widen the mode and make the role non-idempotent."
         type: "str"
         default: "0600"
       file_permissions_opasswd_mode:

--- a/roles/file_permissions/meta/main.yml
+++ b/roles/file_permissions/meta/main.yml
@@ -1,0 +1,28 @@
+---
+galaxy_info:
+  role_name: file_permissions
+  author: konstruktoid
+  description: Ensure account database and bootloader configuration permissions
+  license: apache
+  min_ansible_version: "2.18"
+  platforms:
+    - name: Debian
+      versions:
+        - trixie
+    - name: EL
+      versions:
+        - "10"
+    - name: Ubuntu
+      versions:
+        - resolute
+  galaxy_tags:
+    - almalinux
+    - cis
+    - debian
+    - disa
+    - hardening
+    - permissions
+    - security
+    - system
+    - systemd
+    - ubuntu

--- a/roles/file_permissions/tasks/main.yml
+++ b/roles/file_permissions/tasks/main.yml
@@ -1,0 +1,52 @@
+---
+- name: Configure account database ownership and permissions
+  when:
+    - file_permissions_passwd | bool
+  block:
+    - name: Stat account databases
+      ansible.builtin.stat:
+        path: "{{ item.path }}"
+        get_attributes: false
+        get_checksum: false
+        get_mime: false
+      loop: "{{ file_permissions_account_databases }}"
+      loop_control:
+        label: "{{ item.path }}"
+      register: file_permissions_account_stat
+
+    - name: Set account database ownership and permissions
+      become: true
+      ansible.builtin.file:
+        path: "{{ item.item.path }}"
+        state: file
+        mode: "{{ item.item.mode }}"
+        owner: "{{ item.item.owner }}"
+        group: "{{ item.item.group }}"
+      loop: "{{ file_permissions_account_stat.results | selectattr('stat.exists') | list }}"
+      loop_control:
+        label: "{{ item.item.path }}"
+
+- name: Restrict bootloader configuration permissions
+  become: true
+  when:
+    - file_permissions_bootloader | bool
+  block:
+    - name: Stat bootloader configuration
+      ansible.builtin.stat:
+        path: "{{ item }}"
+        get_attributes: false
+        get_checksum: false
+        get_mime: false
+      loop: "{{ file_permissions_bootloader_files }}"
+      register: file_permissions_bootloader_stat
+
+    - name: Set bootloader configuration permissions
+      ansible.builtin.file:
+        path: "{{ item.item }}"
+        state: file
+        mode: "{{ file_permissions_bootloader_mode }}"
+        owner: root
+        group: root
+      loop: "{{ file_permissions_bootloader_stat.results | selectattr('stat.exists') | rejectattr('stat.mode', 'search', '00$') | list }}"
+      loop_control:
+        label: "{{ item.item }}"

--- a/roles/file_permissions/tasks/main.yml
+++ b/roles/file_permissions/tasks/main.yml
@@ -40,13 +40,17 @@
       loop: "{{ file_permissions_bootloader_files }}"
       register: file_permissions_bootloader_stat
 
-    - name: Set bootloader configuration permissions
+    - name: Set bootloader configuration ownership and permissions
       ansible.builtin.file:
         path: "{{ item.item }}"
         state: file
-        mode: "{{ file_permissions_bootloader_mode }}"
+        mode: "{{ file_permissions_bootloader_mode if item.stat.mode is not search('00$') else omit }}"
         owner: root
         group: root
-      loop: "{{ file_permissions_bootloader_stat.results | selectattr('stat.exists') | rejectattr('stat.mode', 'search', '00$') | list }}"
+      loop: "{{ file_permissions_bootloader_stat.results | selectattr('stat.exists') | list }}"
       loop_control:
         label: "{{ item.item }}"
+      when: >-
+        item.stat.mode is not search('00$')
+        or item.stat.pw_name != 'root'
+        or item.stat.gr_name != 'root'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `file_permissions` role for securing ownership and permissions on account databases, backups, password history files, and bootloader configuration.
  * Supports configurable file modes, ownership, groups, and optional protection controls across supported Linux platforms.
  * The collection now includes 43 independent roles.

* **Documentation**
  * Added usage, configuration, platform support, and execution guidance for the new role.

* **Tests**
  * Added verification coverage for expected ownership and permission settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->