### PR TITLE
set apt lock_timeout and install epel-release as preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Set `lock_timeout` on the `apt` handlers in the `automatic_updates` and `packages` roles,
+  so that cleanup no longer fails when a package management service still holds the apt lock.
+- Install `epel-release` during test preparation instead of mid-play, and document that
+  repository adding roles have to run before the upgrade, so that the repository set is
+  stable across both converges and the idempotence check on AlmaLinux no longer fails.
 - Add `file_permissions` role, restricting the ownership and permissions of the account
   databases (`/etc/passwd`, `/etc/shadow`, `/etc/group`, `/etc/gshadow`, their backup files
   and `/etc/security/opasswd`) and of the bootloader configuration files.

--- a/extensions/molecule/resources/prepare.yml
+++ b/extensions/molecule/resources/prepare.yml
@@ -18,3 +18,13 @@
 
     - name: Gather facts
       ansible.builtin.gather_facts:
+
+    - name: Install epel-release on the RedHat family
+      become: true
+      ansible.builtin.dnf:
+        name: epel-release
+        state: present
+        update_cache: true
+      when:
+        - ansible_facts.os_family == "RedHat"
+        - ansible_facts.virtualization_type not in ["container", "docker", "podman"]

--- a/roles/automatic_updates/handlers/main.yml
+++ b/roles/automatic_updates/handlers/main.yml
@@ -12,11 +12,13 @@
   ansible.builtin.apt:
     autoclean: true
     clean: true
+    lock_timeout: 300
 
 - name: Run apt-get autoremove
   become: true
   ansible.builtin.apt:
     autoremove: true
+    lock_timeout: 300
 
 - name: Run dnf autoremove
   become: true

--- a/roles/package_management/README.md
+++ b/roles/package_management/README.md
@@ -2,6 +2,11 @@
 
 Role to manage configuration of APT and DNF.
 
+Apply any role that adds a package repository before this one when `system_upgrade` is
+enabled. `timesyncd` installs `epel-release` on the RedHat family, for example. A
+repository added after the upgrade has run leaves its packages upgradable, so the next
+run of this role reports changed again.
+
 ## Requirements
 
 - Ansible-core >= 2.18

--- a/roles/packages/handlers/main.yml
+++ b/roles/packages/handlers/main.yml
@@ -4,11 +4,13 @@
   ansible.builtin.apt:
     autoclean: true
     clean: true
+    lock_timeout: 300
 
 - name: Run apt-get autoremove
   become: true
   ansible.builtin.apt:
     autoremove: true
+    lock_timeout: 300
 
 - name: Run dnf autoremove
   become: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of package cleanup and automatic update operations by allowing them to wait for temporary APT locks.
  * Improved stable AlmaLinux test runs by installing required EPEL repositories during preparation and refreshing package metadata.
  * Improved repeatability and idempotence of package management when repository setup is applied in the recommended order.

* **Documentation**
  * Added guidance on ordering repository configuration before system upgrades to prevent repeated package changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->