### PR TITLE
dont enforce unconfined apparmor profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Stop the `apparmor` role from enforcing profiles that declare `flags=(unconfined)`,
+  `flags=(prompt)` or `flags=(default_allow)`. Note that hosts hardened with an earlier
+  release keep the rewritten profiles on disk and have to be restored separately, for example
+  with `apt-get install --reinstall apparmor apparmor-profiles`.
 - Set `lock_timeout` on the `apt` handlers in the `automatic_updates` and `packages` roles,
   so that cleanup no longer fails when a package management service still holds the apt lock.
 - Install `epel-release` during test preparation instead of mid-play, and document that

--- a/extensions/molecule/tests/verify_apparmor.yml
+++ b/extensions/molecule/tests/verify_apparmor.yml
@@ -37,7 +37,7 @@
         paths: /etc/apparmor.d/
         file_type: file
         recurse: false
-        contains: ".*flags\\s*=\\s*\\([^)]*\\bunconfined\\b"
+        contains: "^(?!\\s*#).*flags\\s*=\\s*\\([^)]*\\bunconfined\\b"
       register: apparmor_unconfined_profiles
 
     - name: Find AppArmor profiles that allow everything

--- a/extensions/molecule/tests/verify_apparmor.yml
+++ b/extensions/molecule/tests/verify_apparmor.yml
@@ -22,6 +22,46 @@
           - "'kernel.apparmor_restrict_unprivileged_unconfined = 1' in sysctl_output.stdout"
           - "'kernel.unprivileged_userns_apparmor_policy = 1' in sysctl_output.stdout"
 
+    - name: Find permissive AppArmor stub profiles
+      become: true
+      ansible.builtin.find:
+        paths: /etc/apparmor.d/
+        file_type: file
+        recurse: false
+        contains: "^# This profile allows everything and only exists to give the$"
+      register: apparmor_stub_profiles
+
+    - name: Find AppArmor profiles that kept the unconfined flag
+      become: true
+      ansible.builtin.find:
+        paths: /etc/apparmor.d/
+        file_type: file
+        recurse: false
+        contains: ".*flags\\s*=\\s*\\([^)]*\\bunconfined\\b"
+      register: apparmor_unconfined_profiles
+
+    - name: Find AppArmor profiles that allow everything
+      become: true
+      ansible.builtin.find:
+        paths: /etc/apparmor.d/
+        file_type: file
+        recurse: false
+        contains: "\\s*allow all,"
+      register: apparmor_allow_all_profiles
+
+    - name: Assert that permissive stub profiles are still permissive
+      ansible.builtin.assert:
+        that:
+          - apparmor_broken_stub_profiles | length == 0
+        fail_msg: >-
+          aa-enforce stripped the permissive flags from {{ apparmor_broken_stub_profiles | join(", ") }},
+          turning stub profiles that allow everything into enforcing profiles that deny everything.
+      vars:
+        apparmor_broken_stub_profiles: >-
+          {{ apparmor_stub_profiles.files | map(attribute='path') | list
+             | difference((apparmor_unconfined_profiles.files | map(attribute='path') | list)
+                          | union(apparmor_allow_all_profiles.files | map(attribute='path') | list)) | sort }}
+
     - name: Assert io_uring sysctl setting
       ansible.builtin.assert:
         that:

--- a/roles/apparmor/defaults/main.yml
+++ b/roles/apparmor/defaults/main.yml
@@ -11,3 +11,6 @@ apparmor_sysctl_settings:
 
 # AppArmor sysctl configuration template location.
 sysctl_apparmor_config_template: "etc/sysctl/sysctl.apparmor.conf.j2"
+
+# Profiles matching this expression are left alone by the enforce task.
+apparmor_unenforced_flags_regex: ".*flags\\s*=\\s*\\([^)]*\\b(unconfined|prompt|default_allow)\\b"

--- a/roles/apparmor/defaults/main.yml
+++ b/roles/apparmor/defaults/main.yml
@@ -13,4 +13,4 @@ apparmor_sysctl_settings:
 sysctl_apparmor_config_template: "etc/sysctl/sysctl.apparmor.conf.j2"
 
 # Profiles matching this expression are left alone by the enforce task.
-apparmor_unenforced_flags_regex: ".*flags\\s*=\\s*\\([^)]*\\b(unconfined|prompt|default_allow)\\b"
+apparmor_unenforced_flags_regex: "^(?!\\s*#).*flags\\s*=\\s*\\([^)]*\\b(unconfined|prompt|default_allow)\\b"

--- a/roles/apparmor/tasks/main.yml
+++ b/roles/apparmor/tasks/main.yml
@@ -79,14 +79,44 @@
         - ansible_facts.virtualization_type not in ["container", "docker", "podman"]
 
     - name: Enforce AppArmor profiles
-      ansible.builtin.command:
-        cmd: find /etc/apparmor.d/ -maxdepth 1 -type f -exec aa-enforce {} \;
-      register: enforce_apparmor_profiles
-      changed_when: enforce_apparmor_profiles.rc != 0
-      failed_when: enforce_apparmor_profiles.rc != 0
       when:
         - ansible_facts.virtualization_type not in ["container", "docker", "podman"]
         - get_apparmor_complaining.stdout != "0"
+      block:
+        - name: Find AppArmor profiles
+          ansible.builtin.find:
+            paths: /etc/apparmor.d/
+            file_type: file
+            recurse: false
+          register: apparmor_profiles
+
+        - name: Find AppArmor profiles that are deliberately not enforced
+          ansible.builtin.find:
+            paths: /etc/apparmor.d/
+            file_type: file
+            recurse: false
+            contains: "{{ apparmor_unenforced_flags_regex }}"
+          register: apparmor_unenforced_profiles
+
+        - name: Enforce AppArmor profiles not flagged as unenforced
+          environment:
+            PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+          ansible.builtin.command:
+            cmd: "aa-enforce {{ item }}"
+          loop: >-
+            {{ apparmor_profiles.files | map(attribute='path') | list
+               | difference(apparmor_unenforced_profiles.files | map(attribute='path') | list) | sort }}
+          register: enforce_apparmor_profiles
+          changed_when: true
+          failed_when: false
+
+        - name: Warn about AppArmor profiles that could not be enforced
+          ansible.builtin.debug:
+            msg: >-
+              aa-enforce failed for {{ enforce_apparmor_profiles.results
+                | rejectattr('rc', 'equalto', 0) | map(attribute='item') | join(", ") }}
+          when:
+            - enforce_apparmor_profiles.results | rejectattr('rc', 'equalto', 0) | list | length > 0
 
     - name: Enable apparmor
       ansible.builtin.systemd_service:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AppArmor enforcement now skips profiles marked as `unconfined`, `prompt`, or `default_allow`.
  * Remaining profiles are enforced individually, with warnings identifying any profiles that could not be enforced.

* **Bug Fixes**
  * Added validation to detect permissive or improperly configured AppArmor profiles.

* **Documentation**
  * Updated the unreleased changelog with the new profile-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->