### PR TITLE
remove the unused `sshd_admin_net` variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Remove the unused `sshd_admin_net` variable from the `ssh` role. It is a leftover from
+  `ansible-role-hardening`, where the role also managed the firewall, and it has had no effect
+  since firewalling moved to the separate `ufw` and `firewalld` roles. Use `ufw_admin_net` or
+  `firewalld_admin_net` to restrict which networks may connect.
 - Stop the `apparmor` role from enforcing profiles that declare `flags=(unconfined)`,
   `flags=(prompt)` or `flags=(default_allow)`. Note that hosts hardened with an earlier
   release keep the rewritten profiles on disk and have to be restored separately, for example

--- a/roles/ssh/README.md
+++ b/roles/ssh/README.md
@@ -24,7 +24,6 @@ Defined in `roles/ssh/defaults/main.yml`.
 | --- | --- | --- |
 | `ssh_config_template` | `"etc/ssh/ssh_config.j2"` | OpenSSH ssh_config template location. |
 | `sshd_accept_env` | `"LANG LC_*"` | Specifies what environment variables sent by the client will be copied into the session. |
-| `sshd_admin_net` | `["192.168.0.0/24", "192.168.1.0/24"]` | Only the network(s) defined in `sshd_admin_net` are allowed to connect to `sshd_ports`. |
 | `sshd_allow_agent_forwarding` | `false` | Specifies whether ssh-agent forwarding is permitted. |
 | `sshd_allow_groups` | `["sudo"]` | If specified, login is allowed only for users whose primary group or supplementary group list matches one of the patterns. |
 | `sshd_allow_tcp_forwarding` | `false` | Specifies whether TCP forwarding is permitted. |

--- a/roles/ssh/defaults/main.yml
+++ b/roles/ssh/defaults/main.yml
@@ -5,8 +5,6 @@ ssh_config_template: "etc/ssh/ssh_config.j2"
 # Specifies what environment variables sent by the client will be copied into the session.
 sshd_accept_env: "LANG LC_*"
 
-# Only the network(s) defined in C(sshd_admin_net) are allowed to connect to C(sshd_ports).
-sshd_admin_net: ["192.168.0.0/24", "192.168.1.0/24"]
 # Specifies whether ssh-agent forwarding is permitted.
 sshd_allow_agent_forwarding: false
 

--- a/roles/ssh/meta/argument_specs.yml
+++ b/roles/ssh/meta/argument_specs.yml
@@ -15,13 +15,6 @@ argument_specs:
         description: "Specifies what environment variables sent by the client will be copied into the session."
         type: "str"
         default: "LANG LC_*"
-      sshd_admin_net:
-        description: "Only the network(s) defined in C(sshd_admin_net) are allowed to connect to C(sshd_ports)."
-        type: "list"
-        elements: "str"
-        default:
-          - "192.168.0.0/24"
-          - "192.168.1.0/24"
       sshd_allow_agent_forwarding:
         description: "Specifies whether ssh-agent forwarding is permitted."
         type: "bool"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the changelog and SSH role documentation to reflect removal of the unused `sshd_admin_net` setting.
  - Documented the available firewall network restriction settings for SSH access.

- **Breaking Changes**
  - Removed the public `sshd_admin_net` option from SSH role configuration. Existing configurations should use the appropriate firewall network setting instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->