### PR TITLE
add chrony role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,22 @@
   (`rsh-redone-client`, `rsh-redone-server`, `rusersd`, `rwho`), `rsync-daemon` and the
   remaining telnet and TFTP server package names (`inetutils-telnetd`, `telnetd`,
   `tftp-server`). Override `packages_blocklist` on hosts that legitimately run any of these.
+- Add `chrony` role, configuring `chrony` as a client only NTP daemon and as the single time
+  synchronization service on the host: NTS authenticated sources only, `authselectmode require`,
+  `minsources 3`, no NTP port, no command port and no `sourcedir`/`confdir` includes, so that a
+  DHCP server cannot add unauthenticated sources. Serving time is opt-in behind
+  `chrony_server_enabled`. The role ships no systemd drop-in, the packaged units are already
+  hardened. It is the alternative to the `timesyncd` role, apply one or the other.
+  The role also installs `ca-certificates`, which is not a dependency of the `chrony` package on
+  the Debian family: NTS is TLS, and without a trust store every NTS-KE handshake fails with
+  `The certificate issuer is unknown` and the host never synchronizes its clock.
+- Extend `timesyncd_conflicting_services` with `chronyd-restricted.service` and
+  `ntpd-rs.service`, so that switching a host to `systemd-timesyncd` also stops the restricted
+  `chronyd` variant both families package, and `ntpd-rs`, which Debian trixie packages.
+- Converge and verify the `chrony` role instead of the `timesyncd` role in the Molecule
+  scenarios. Both roles disable the other one, so only one of them can be tested per host, and
+  `chrony` is what the supported platforms ship. `extensions/molecule/tests/verify_timesyncd.yml`
+  is kept for scenarios that select `timesyncd` instead.
 
 ## 0.2.0 (2026-07-23)
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ role. See each role's `README.md` for its variables and example usage.
 | [`apport`](roles/apport/README.md) | Manage Apport. | Debian, Ubuntu |
 | [`auditd`](roles/auditd/README.md) | Install and configure auditd and manage audit rules on AlmaLinux, Debian, and Ubuntu. | Debian, AlmaLinux/EL, Ubuntu |
 | [`automatic_updates`](roles/automatic_updates/README.md) | Configure unattended-upgrades to automatically install security updates. | Debian, AlmaLinux/EL, Ubuntu |
+| [`chrony`](roles/chrony/README.md) | Ansible role to manage chrony configuration. | Debian, AlmaLinux/EL, Ubuntu |
 | [`compilers`](roles/compilers/README.md) | Restrict compiler binaries to root on AlmaLinux, Debian, and Ubuntu systems. | Debian, AlmaLinux/EL, Ubuntu |
 | [`ctrlaltdel`](roles/ctrlaltdel/README.md) | Disable Ctrl+Alt+Del key sequence to prevent reboots. | Debian, AlmaLinux/EL, Ubuntu |
 | [`delete_users`](roles/delete_users/README.md) | Delete listed users. | Debian, AlmaLinux/EL, Ubuntu |

--- a/extensions/molecule/resources/converge.yml
+++ b/extensions/molecule/resources/converge.yml
@@ -32,7 +32,7 @@
     - role: konstruktoid.hardening.automatic_updates
     - role: konstruktoid.hardening.systemdconf
     - role: konstruktoid.hardening.journald
-    - role: konstruktoid.hardening.timesyncd
+    - role: konstruktoid.hardening.chrony
     - role: konstruktoid.hardening.prelink
     - role: konstruktoid.hardening.logindconf
     - role: konstruktoid.hardening.netplan

--- a/extensions/molecule/resources/verify.yml
+++ b/extensions/molecule/resources/verify.yml
@@ -93,9 +93,9 @@
       ansible.builtin.include_tasks:
         file: ../tests/verify_journald.yml
 
-    - name: Verify timesyncd role
+    - name: Verify chrony role
       ansible.builtin.include_tasks:
-        file: ../tests/verify_timesyncd.yml
+        file: ../tests/verify_chrony.yml
 
     - name: Verify prelink role
       ansible.builtin.include_tasks:

--- a/extensions/molecule/tests/verify_chrony.yml
+++ b/extensions/molecule/tests/verify_chrony.yml
@@ -1,0 +1,177 @@
+---
+- name: Verify chrony configuration
+  when:
+    - ansible_facts.virtualization_type not in ["container", "docker", "podman"]
+  block:
+    - name: Get chrony service status
+      ansible.builtin.systemd_service:
+        name: "{{ chrony_service }}"
+      register: chrony_service_status
+
+    # CIS 2.3.1.1 and 2.3.3.3.
+    - name: Assert chrony is unmasked, enabled and active
+      ansible.builtin.assert:
+        that:
+          - chrony_service_status.status.LoadState == "loaded"
+          - chrony_service_status.status.UnitFileState == "enabled"
+          - chrony_service_status.status.ActiveState == "active"
+        fail_msg: >-
+          {{ chrony_service }} is not unmasked, enabled and active.
+          LoadState: {{ chrony_service_status.status.LoadState }},
+          UnitFileState: {{ chrony_service_status.status.UnitFileState | default('none') }},
+          ActiveState: {{ chrony_service_status.status.ActiveState }}
+
+    - name: Get conflicting time synchronization service status
+      ansible.builtin.systemd_service:
+        name: "{{ item }}"
+      register: chrony_conflicting
+      loop: "{{ chrony_conflicting_services }}"
+
+    # CIS 2.3.1.1, exactly one time synchronization service.
+    - name: Assert no conflicting time synchronization service is enabled or active
+      ansible.builtin.assert:
+        that:
+          - item.status.ActiveState != "active"
+          - item.status.UnitFileState | default("") not in ["enabled", "enabled-runtime"]
+        fail_msg: >-
+          {{ item.item }} still synchronizes the system clock.
+          UnitFileState: {{ item.status.UnitFileState | default('none') }},
+          ActiveState: {{ item.status.ActiveState }}
+      loop: "{{ chrony_conflicting.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+
+    # Not the MainPID of the unit: on Ubuntu that is the root owned
+    # /usr/lib/systemd/scripts/chronyd-starter.sh wrapper, and the chronyd
+    # processes it starts are the ones that have to be unprivileged.
+    - name: Get the chronyd process owners
+      become: true
+      ansible.builtin.shell:
+        cmd: |
+          set -o pipefail
+          ps -o user= -C chronyd | sort -u
+      register: chrony_process_owners
+      changed_when: false
+
+    # CIS 2.3.3.2, chronyd is not running as root.
+    - name: Assert chronyd runs as the unprivileged chrony user
+      ansible.builtin.assert:
+        that:
+          - chrony_process_owners.stdout_lines | length > 0
+          - chrony_process_owners.stdout_lines == [chrony_user]
+        fail_msg: >-
+          chronyd runs as {{ chrony_process_owners.stdout_lines | join(', ') | default('nobody', true) }}
+          and not as {{ chrony_user }}.
+
+    - name: Stat the chrony configuration
+      become: true
+      ansible.builtin.stat:
+        path: "{{ chrony_conf }}"
+        get_attributes: false
+        get_checksum: false
+        get_mime: false
+      register: chrony_conf_stat
+
+    - name: Assert the chrony configuration ownership and permissions
+      ansible.builtin.assert:
+        that:
+          - chrony_conf_stat.stat.exists
+          - chrony_conf_stat.stat.mode == chrony_conf_mode
+          - chrony_conf_stat.stat.pw_name == "root"
+          - chrony_conf_stat.stat.gr_name == "root"
+        fail_msg: >-
+          {{ chrony_conf }} ownership or permissions are incorrect:
+          {{ chrony_conf_stat.stat.mode }}
+          {{ chrony_conf_stat.stat.pw_name }}:{{ chrony_conf_stat.stat.gr_name }},
+          expected {{ chrony_conf_mode }} root:root
+
+    - name: Read the chrony configuration
+      become: true
+      ansible.builtin.slurp:
+        src: "{{ chrony_conf }}"
+      register: chrony_conf_content
+
+    # CIS 2.3.3.1, the configuration has a source. The sources are written to
+    # the main configuration file, so no sourcedir or confdir include has to be
+    # followed to find them.
+    - name: Assert the configured time sources are in the chrony configuration
+      ansible.builtin.assert:
+        that:
+          - chrony_source_line in chrony_conf_lines
+        fail_msg: "{{ chrony_source_line }} is missing from {{ chrony_conf }}"
+      loop: "{{ chrony_sources }}"
+      loop_control:
+        label: "{{ item.address }}"
+      vars:
+        chrony_conf_lines: "{{ (chrony_conf_content.content | b64decode).splitlines() }}"
+        chrony_source_line: "{{ item.type }} {{ item.address }} {{ item.options | join(' ') }}"
+
+    - name: Assert the chrony client configuration
+      ansible.builtin.assert:
+        that:
+          - "'user ' ~ chrony_user in chrony_conf_lines"
+          - "'minsources ' ~ chrony_minsources in chrony_conf_lines"
+          - "'port ' ~ chrony_port in chrony_conf_lines"
+          - "'cmdport ' ~ chrony_cmdport in chrony_conf_lines"
+          - "'driftfile ' ~ chrony_driftfile in chrony_conf_lines"
+          - "('authselectmode ' ~ chrony_authselectmode in chrony_conf_lines) or chrony_authselectmode | length == 0"
+          - "('noclientlog' in chrony_conf_lines) or not chrony_noclientlog"
+          - "('rtcsync' in chrony_conf_lines) or not chrony_rtcsync"
+          - "('rtconutc' in chrony_conf_lines) == chrony_rtconutc"
+        fail_msg: "{{ chrony_conf }} does not match the configured values."
+      vars:
+        chrony_conf_lines: "{{ (chrony_conf_content.content | b64decode).splitlines() }}"
+
+    - name: Get timedatectl NTP status
+      become: true
+      ansible.builtin.command:
+        cmd: timedatectl show --property=NTP --value
+      register: chrony_timedatectl
+      changed_when: false
+
+    - name: Assert network time synchronization is enabled
+      ansible.builtin.assert:
+        that:
+          - chrony_timedatectl.stdout == "yes"
+        fail_msg: "timedatectl reports NTP={{ chrony_timedatectl.stdout }}"
+
+    # NTS needs outbound 4460/tcp. Where it is filtered chronyd reports the
+    # sources without a key and without cookies, and there is nothing to assert.
+    - name: Get the chrony NTS authentication data
+      become: true
+      ansible.builtin.command:
+        cmd: chronyc -N -c authdata
+      register: chrony_authdata
+      changed_when: false
+      failed_when: false
+
+    - name: Assert the NTS sources are authenticated
+      ansible.builtin.assert:
+        that:
+          - item.split(",")[2] | int > 0
+          - item.split(",")[4] | int > 0
+        fail_msg: >-
+          {{ item.split(',')[0] }} negotiated no NTS key:
+          KeyID {{ item.split(',')[2] }}, KLen {{ item.split(',')[4] }}
+      loop: "{{ chrony_authdata.stdout_lines | select('search', '^[^,]+,NTS,') | list }}"
+      loop_control:
+        label: "{{ item.split(',')[0] }}"
+      when: chrony_authdata.rc == 0
+
+    # chronyd spends a cookie on every request and only refills from the
+    # replies, so a source that is slow to answer legitimately reports Cook 0
+    # at the moment chronyc is run. Requiring cookies of every source is a race
+    # with the poll interval, requiring them of at least one is not, and it is
+    # what shows that the cookie exchange works at all. The regular expression
+    # matches a non-zero ninth field, which is Cook.
+    - name: Assert at least one NTS source holds cookies
+      ansible.builtin.assert:
+        that:
+          - chrony_nts_sources | select("search", "^([^,]*,){8}[1-9]") | list | length > 0
+        fail_msg: >-
+          No NTS source holds cookies: {{ chrony_nts_sources | join(' ') }}
+      vars:
+        chrony_nts_sources: "{{ chrony_authdata.stdout_lines | select('search', '^[^,]+,NTS,') | list }}"
+      when:
+        - chrony_authdata.rc == 0
+        - chrony_nts_sources | length > 0

--- a/extensions/molecule/tests/verify_chrony.yml
+++ b/extensions/molecule/tests/verify_chrony.yml
@@ -46,22 +46,23 @@
     # processes it starts are the ones that have to be unprivileged.
     - name: Get the chronyd process owners
       become: true
-      ansible.builtin.shell:
-        cmd: |
-          set -o pipefail
-          ps -o user= -C chronyd | sort -u
+      ansible.builtin.command:
+        cmd: ps -o user= -C chronyd
       register: chrony_process_owners
       changed_when: false
+      failed_when: false
 
     # CIS 2.3.3.2, chronyd is not running as root.
     - name: Assert chronyd runs as the unprivileged chrony user
       ansible.builtin.assert:
         that:
-          - chrony_process_owners.stdout_lines | length > 0
-          - chrony_process_owners.stdout_lines == [chrony_user]
+          - chrony_owners | length > 0
+          - chrony_owners == [chrony_user]
         fail_msg: >-
-          chronyd runs as {{ chrony_process_owners.stdout_lines | join(', ') | default('nobody', true) }}
+          chronyd runs as {{ chrony_owners | join(', ') | default('nobody', true) }}
           and not as {{ chrony_user }}.
+      vars:
+        chrony_owners: "{{ chrony_process_owners.stdout_lines | map('trim') | unique | sort | list }}"
 
     - name: Stat the chrony configuration
       become: true

--- a/roles/chrony/README.md
+++ b/roles/chrony/README.md
@@ -1,0 +1,152 @@
+# chrony
+
+Ansible role to manage chrony configuration.
+
+The role configures chrony as a client only NTP daemon: it does not open the NTP port, it does
+not open the command port, and every time source it configures is authenticated with
+[Network Time Security](https://datatracker.ietf.org/doc/html/rfc8915). Serving time to other
+hosts is possible, but it is strictly opt-in, see `chrony_server_enabled`.
+
+Any other time synchronization service, listed in `chrony_conflicting_services`, is stopped and
+disabled so that chrony is the only service synchronizing the system clock. This is the same
+mutual exclusion the [`timesyncd`](../timesyncd/README.md) role does in the other direction, and
+running either role last leaves the host with a single time source. The two roles are
+alternatives, do not apply both to the same host and expect both to keep running.
+
+The default sources, `time.cloudflare.com`, `ntppool1.time.nl`, `nts.netnod.se` and
+`ptbtime1.ptb.de`, are a supply chain decision and not only a time decision: they are the
+organizations a host asks what time it is, and they see the host asking. Review
+`chrony_sources` before using the defaults.
+
+`chrony_authselectmode` is `require` by default, which means chronyd refuses to select a source
+that is not authenticated. Every default source supports NTS, so this changes nothing until an
+unauthenticated source is added, and the role then fails the run rather than letting the host
+fall back to spoofable time. On a network that filters outbound 4460/tcp, or on a host that
+comes up with a clock too wrong to validate a certificate, it turns a degraded synchronization
+into no synchronization at all. `chrony_nocerttimecheck` handles the second case, and setting
+`chrony_authselectmode` to `ignore` handles the first.
+
+The NTP port, 123/udp, and the NTS-KE port, 4460/tcp, are managed by the
+[`ufw`](../ufw/README.md) and [`firewalld`](../firewalld/README.md) roles, not by this one.
+
+## Requirements
+
+- Ansible-core >= 2.18
+
+## Supported platforms
+
+| Platform | Versions |
+| --- | --- |
+| Debian | trixie |
+| EL | 10 |
+| Ubuntu | resolute |
+
+## Role variables
+
+Defined in `roles/chrony/defaults/main.yml`.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `chrony_authselectmode` | `"require"` | Authentication required for a source to be selected. `require` rejects every unauthenticated source, `ignore` is the chronyd default. Set to an empty string to leave the directive out. |
+| `chrony_cmdport` | `0` | UDP port chronyd listens on for chronyc command packets. `0` disables it, chronyc still works for root over the Unix domain socket. |
+| `chrony_conf` | `"/etc/chrony/chrony.conf"` on the Debian family, `"/etc/chrony.conf"` otherwise | Path of the chrony configuration file. |
+| `chrony_conf_mode` | `"0644"` | File mode of the chrony configuration file. |
+| `chrony_conf_template` | `"etc/chrony/chrony.conf.j2"` | chrony.conf template location. |
+| `chrony_confdirs` | `[]` | Directories scanned for additional configuration files, `confdir` directives. |
+| `chrony_conflicting_services` | `["systemd-timesyncd.service", "ntp.service", "ntpd.service", "ntpsec.service", "openntpd.service", "ntpd-rs.service", "chronyd-restricted.service"]` | Services that also synchronize the system clock. They are stopped and disabled so that chrony is the only time synchronization service on the host. |
+| `chrony_driftfile` | `"/var/lib/chrony/chrony.drift"` on the Debian family, `"/var/lib/chrony/drift"` otherwise | File in which chronyd records the rate at which the system clock gains or loses time. |
+| `chrony_dumpdir` | `"/run/chrony"` | Directory in which chronyd saves the measurement history. |
+| `chrony_group` | `"_chrony"` on the Debian family, `"chrony"` otherwise | Group of the chrony daemon user. |
+| `chrony_leapseclist` | `"/usr/share/zoneinfo/leap-seconds.list"` | File containing the TAI-UTC offset and the leap seconds. The directive is only written when the file exists on the target. |
+| `chrony_logdir` | `"/var/log/chrony"` | Directory in which chronyd writes its log files. |
+| `chrony_makestep` | `"1.0 3"` | Step the clock instead of slewing it if the correction is larger than the first value, for the first number of updates given by the second value. |
+| `chrony_minsources` | `3` | Minimum number of selectable sources required to adjust the system clock. |
+| `chrony_noclientlog` | `true` | If True, no per client access logs are kept. |
+| `chrony_nocerttimecheck` | `0` | Number of clock updates for which the NTS-KE certificate time checks are disabled. `0` keeps the checks. |
+| `chrony_ntsdumpdir` | `"/var/lib/chrony"` | Directory in which chronyd saves NTS keys and cookies. |
+| `chrony_ntsprocesses` | `1` | Number of helper processes handling NTS-KE sessions. |
+| `chrony_ntsservercert` | `"/etc/chrony/nts-server.crt"` on the Debian family, `"/etc/pki/tls/certs/chrony-nts.crt"` otherwise | Certificate, or certificate chain, presented to NTS clients. |
+| `chrony_ntsservercert_mode` | `"0644"` | File mode of `chrony_ntsservercert`. |
+| `chrony_ntsserverkey` | `"/etc/chrony/nts-server.key"` on the Debian family, `"/etc/pki/tls/private/chrony-nts.key"` otherwise | Private key of the NTS server certificate. |
+| `chrony_ntsserverkey_mode` | `"0640"` | File mode of `chrony_ntsserverkey`. It is owned by root and readable by `chrony_group`. |
+| `chrony_packages` | `["chrony", "ca-certificates"]` | Packages required to synchronize the clock over NTS. |
+| `chrony_port` | `0` | UDP port chronyd listens on for NTP requests. `0` means the host is a client only. |
+| `chrony_ratelimit_burst` | `16` | Number of requests a client may send faster than `chrony_ratelimit_interval` before chronyd starts dropping them. |
+| `chrony_ratelimit_interval` | `1` | Interval, as a power of two seconds, between responses to a client before chronyd starts dropping requests. |
+| `chrony_rtconutc` | `false` | If True, the real time clock is assumed to keep UTC. Wrong for hosts that dual boot an operating system that keeps local time in the RTC. |
+| `chrony_rtcsync` | `true` | If True, the real time clock is synchronized from the system clock every 11 minutes. |
+| `chrony_server_allow` | `[]` | Networks allowed to use the host as a time source, `allow` directives. An empty list serves nobody. |
+| `chrony_server_enabled` | `false` | If True, the host serves time to the networks listed in `chrony_server_allow`. It requires `chrony_port` to be a real port. |
+| `chrony_service` | `"chrony.service"` on the Debian family, `"chronyd.service"` otherwise | Name of the chrony systemd unit. |
+| `chrony_sourcedirs` | `[]` | Directories scanned for additional source files, `sourcedir` directives. |
+| `chrony_sources` | `[{"address": "time.cloudflare.com", "type": "server", "options": ["iburst", "nts"]}, {"address": "ntppool1.time.nl", "type": "server", "options": ["iburst", "nts"]}, {"address": "nts.netnod.se", "type": "server", "options": ["iburst", "nts"]}, {"address": "ptbtime1.ptb.de", "type": "server", "options": ["iburst", "nts"]}]` | Time sources. Every source is emitted as `<type> <address> <options>`. |
+| `chrony_user` | `"_chrony"` on the Debian family, `"chrony"` otherwise | User chronyd drops its privileges to. |
+
+## Notes
+
+`ca-certificates` is installed together with `chrony`. It is not a dependency of the `chrony`
+package on the Debian family, and NTS is TLS: without a trust store every NTS-KE handshake fails
+with `The certificate issuer is unknown`, and `authselectmode require` then leaves the host with
+`Can't synchronise: no selectable sources`.
+
+`chrony_sourcedirs` and `chrony_confdirs` are empty by default, which means the packaged
+`sourcedir /run/chrony-dhcp`, `sourcedir /etc/chrony/sources.d` and `confdir /etc/chrony/conf.d`
+includes are not written. The configuration of a host is then the single file this role manages.
+On Ubuntu that also means the `sources.d` NTS pools and the `conf.d` bootstrap CA the package
+ships are no longer read. Add the directories back if you want them.
+
+The systemd units the distributions ship for chrony already set `ProtectSystem=strict`,
+`ProtectProc=invisible`, `MemoryDenyWriteExecute=yes`, `PrivateTmp=yes`, `DevicePolicy=closed`,
+`SystemCallFilter`, a trimmed `CapabilityBoundingSet` and dedicated
+`RuntimeDirectory`/`StateDirectory`/`LogsDirectory` entries. The role therefore ships no drop-in:
+there is nothing left worth adding that does not also break the reference clock, RTC or
+`mailonchange` paths those units deliberately keep open.
+
+On the Debian family, the AppArmor profile shipped with the package only lets chronyd read
+`/etc/chrony/**` and `/etc/chrony.*`. An NTS server key or certificate has to be placed under
+`/etc/chrony` there, and the configuration cannot be validated through the `validate` argument of
+the template module, since chronyd may not read the temporary file it creates. The role writes
+the configuration, keeps a backup, parses it with `chronyd -p` and restores the backup when
+chronyd rejects it.
+
+## Tasks
+
+`tasks/main.yml` executes, in order:
+
+1. Install and configure chrony
+2. Assert that the time sources are usable
+3. Assert that every time source is authenticated
+4. Assert that a time server accepts NTP requests
+5. Install chrony
+6. Stat the leap second list
+7. Set the NTS server key and certificate ownership and permissions
+8. Configure chrony
+9. Validate the chrony configuration
+10. Parse the chrony configuration
+11. Restore the previous chrony configuration
+12. Fail because chronyd rejected the configuration
+13. Gather service facts
+14. Stop conflicting time synchronization services
+15. Disable conflicting time synchronization services
+16. Start chrony
+
+## Handlers
+
+- Restart chrony
+
+## Example playbook
+
+```yaml
+- hosts: all
+  become: true
+  roles:
+    - konstruktoid.hardening.chrony
+```
+
+## Tags
+
+`almalinux`, `chrony`, `cis`, `debian`, `disa`, `hardening`, `ntp`, `security`, `system`, `ubuntu`
+
+## License
+
+Apache-2.0

--- a/roles/chrony/defaults/main.yml
+++ b/roles/chrony/defaults/main.yml
@@ -1,0 +1,168 @@
+---
+# Packages required to synchronize the clock over NTS. C(ca-certificates) is
+# not a dependency of the C(chrony) package on the Debian family, and without a
+# trust store every NTS-KE handshake fails with an unknown certificate issuer,
+# which with C(chrony_authselectmode) set to C(require) leaves the clock
+# unsynchronized.
+chrony_packages:
+  - "chrony"
+  - "ca-certificates"
+
+# chrony.conf template location.
+chrony_conf_template: "etc/chrony/chrony.conf.j2"
+
+# Path of the chrony configuration file. The Debian family patches chronyd to
+# read C(/etc/chrony/chrony.conf), the Red Hat family keeps the upstream
+# C(/etc/chrony.conf).
+chrony_conf: "{{ '/etc/chrony/chrony.conf' if ansible_facts.os_family == 'Debian' else '/etc/chrony.conf' }}"
+
+# File mode of the chrony configuration file. C(chronyd) parses it as root
+# before dropping privileges, so it does not have to be group readable, but the
+# packages ship it world readable and nothing in it is secret.
+chrony_conf_mode: "0644"
+
+# Name of the chrony systemd unit. The Debian family names the unit
+# C(chrony.service) and only adds the C(chronyd.service) alias when the unit is
+# enabled, the Red Hat family names it C(chronyd.service) and has no
+# C(chrony.service) at all.
+chrony_service: "{{ 'chrony.service' if ansible_facts.os_family == 'Debian' else 'chronyd.service' }}"
+
+# User C(chronyd) drops its privileges to. The Debian family uses the reserved
+# C(_chrony) name, the Red Hat family uses C(chrony).
+chrony_user: "{{ '_chrony' if ansible_facts.os_family == 'Debian' else 'chrony' }}"
+
+# Group of the chrony daemon user.
+chrony_group: "{{ '_chrony' if ansible_facts.os_family == 'Debian' else 'chrony' }}"
+
+# File in which C(chronyd) records the rate at which the system clock gains or
+# loses time.
+chrony_driftfile: "{{ '/var/lib/chrony/chrony.drift' if ansible_facts.os_family == 'Debian' else '/var/lib/chrony/drift' }}"
+
+# Directory in which C(chronyd) saves NTS keys and cookies, so that a restart
+# does not require a new NTS-KE session with every source.
+chrony_ntsdumpdir: "/var/lib/chrony"
+
+# Directory in which C(chronyd) saves the measurement history. It has to be the
+# runtime directory of the unit, which is the only writable path left by
+# C(RuntimeDirectory=chrony) and C(ProtectSystem=strict).
+chrony_dumpdir: "/run/chrony"
+
+# Directory in which C(chronyd) writes its log files.
+chrony_logdir: "/var/log/chrony"
+
+# Time sources. Every source is emitted as C(<type> <address> <options>), where
+# I(type) is either C(server) or C(pool).
+# The default sources all support NTS, which is what makes
+# C(chrony_authselectmode: "require") usable. Which organizations a host asks
+# for the time is a supply chain decision, review the list before using it.
+chrony_sources:
+  - address: "time.cloudflare.com"
+    type: "server"
+    options: ["iburst", "nts"]
+  - address: "ntppool1.time.nl"
+    type: "server"
+    options: ["iburst", "nts"]
+  - address: "nts.netnod.se"
+    type: "server"
+    options: ["iburst", "nts"]
+  - address: "ptbtime1.ptb.de"
+    type: "server"
+    options: ["iburst", "nts"]
+
+# Directories scanned for additional source files, C(sourcedir) directives.
+# Empty by default: the packaged configurations read C(/run/chrony-dhcp), which
+# adds whatever unauthenticated servers a DHCP server hands out.
+chrony_sourcedirs: []
+
+# Directories scanned for additional configuration files, C(confdir)
+# directives. Empty by default so that the configuration of a host is the file
+# this role manages and nothing else.
+chrony_confdirs: []
+
+# Minimum number of selectable sources required to adjust the system clock.
+chrony_minsources: 3
+
+# Authentication required for a source to be selected. C(require) rejects every
+# unauthenticated source, C(ignore) is the C(chronyd) default and selects
+# sources regardless of authentication. Set to an empty string to leave the
+# directive out.
+chrony_authselectmode: "require"
+
+# Number of clock updates for which the NTS-KE certificate time checks are
+# disabled. Needed only to break the bootstrap deadlock on hosts that come up
+# with a clock wrong enough to make every certificate look expired, which stops
+# NTS, which is the only way left to correct the clock. C(0) keeps the checks.
+chrony_nocerttimecheck: 0
+
+# Threshold and limit of the C(makestep) directive: step the clock instead of
+# slewing it if the correction is larger than the first value, for the first
+# number of updates given by the second value.
+chrony_makestep: "1.0 3"
+
+# Synchronize the real time clock from the system clock every 11 minutes.
+chrony_rtcsync: true
+
+# Assume the real time clock keeps UTC. Wrong for hosts that dual boot an
+# operating system that keeps local time in the RTC.
+chrony_rtconutc: false
+
+# File containing the TAI-UTC offset and the leap seconds, C(leapseclist). The
+# directive is only written when the file exists on the target.
+chrony_leapseclist: "/usr/share/zoneinfo/leap-seconds.list"
+
+# UDP port C(chronyd) listens on for NTP requests. C(0) means the host is a
+# client only and never answers NTP.
+chrony_port: 0
+
+# UDP port C(chronyd) listens on for C(chronyc) command packets. C(0) disables
+# it, C(chronyc) still works for root over the Unix domain socket.
+chrony_cmdport: 0
+
+# Do not keep per client access logs. Only relevant when serving time, it stops
+# the memory a remote client can make C(chronyd) allocate.
+chrony_noclientlog: true
+
+# Services that also synchronize the system clock. They are stopped and
+# disabled so that chrony is the only time synchronization service on the host.
+chrony_conflicting_services:
+  - "systemd-timesyncd.service"
+  - "ntp.service"
+  - "ntpd.service"
+  - "ntpsec.service"
+  - "openntpd.service"
+  - "ntpd-rs.service"
+  - "chronyd-restricted.service"
+
+# Serve time to other hosts. Opt-in, and it requires C(chrony_port) to be a
+# real port and C(chrony_server_allow) to list the networks that may ask.
+chrony_server_enabled: false
+
+# Networks allowed to use the host as a time source, C(allow) directives. An
+# empty list serves nobody.
+chrony_server_allow: []
+
+# Private key of the NTS server certificate. On the Debian family it has to
+# stay under C(/etc/chrony), the AppArmor profile of C(chronyd) denies reads
+# anywhere else.
+chrony_ntsserverkey: "{{ '/etc/chrony/nts-server.key' if ansible_facts.os_family == 'Debian' else '/etc/pki/tls/private/chrony-nts.key' }}"
+
+# Certificate, or certificate chain, presented to NTS clients.
+chrony_ntsservercert: "{{ '/etc/chrony/nts-server.crt' if ansible_facts.os_family == 'Debian' else '/etc/pki/tls/certs/chrony-nts.crt' }}"
+
+# File mode of C(chrony_ntsserverkey). It is owned by C(root) and readable by
+# C(chrony_group), which is the account C(chronyd) drops to.
+chrony_ntsserverkey_mode: "0640"
+
+# File mode of C(chrony_ntsservercert).
+chrony_ntsservercert_mode: "0644"
+
+# Number of helper processes handling NTS-KE sessions.
+chrony_ntsprocesses: 1
+
+# Interval, as a power of two seconds, between responses to a client before
+# C(chronyd) starts dropping requests.
+chrony_ratelimit_interval: 1
+
+# Number of requests a client may send faster than C(chrony_ratelimit_interval)
+# before C(chronyd) starts dropping them.
+chrony_ratelimit_burst: 16

--- a/roles/chrony/handlers/main.yml
+++ b/roles/chrony/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Restart chrony
+  become: true
+  ansible.builtin.systemd_service:
+    name: "{{ chrony_service }}"
+    state: restarted
+  when:
+    - ansible_facts.virtualization_type not in ["container", "docker", "podman"]

--- a/roles/chrony/meta/argument_specs.yml
+++ b/roles/chrony/meta/argument_specs.yml
@@ -1,0 +1,228 @@
+---
+argument_specs:
+  main:
+    short_description: "chrony configuration."
+    description:
+      - "This role configures chrony as a client only NTP daemon, using Network Time Security authenticated sources."
+      - "Any other time synchronization service is stopped and disabled, so that chrony is the only one running."
+    author:
+      - "Thomas Sjögren (@konstruktoid)"
+    options:
+      chrony_packages:
+        description:
+          - "Packages required to synchronize the clock over NTS."
+          - "C(ca-certificates) is not a dependency of the C(chrony) package on the Debian family."
+          - "Without a trust store every NTS-KE handshake fails with an unknown certificate issuer."
+          - "With C(chrony_authselectmode) set to C(require) the clock is then never synchronized."
+        type: "list"
+        elements: "str"
+        default:
+          - "chrony"
+          - "ca-certificates"
+      chrony_conf_template:
+        description: "chrony.conf template location."
+        type: "path"
+        default: "etc/chrony/chrony.conf.j2"
+      chrony_conf:
+        description:
+          - "Path of the chrony configuration file."
+          - "The Debian family patches chronyd to read C(/etc/chrony/chrony.conf), the Red Hat family keeps the upstream C(/etc/chrony.conf)."
+          - "Defaults to C(/etc/chrony/chrony.conf) on the Debian family and to C(/etc/chrony.conf) otherwise."
+        type: "path"
+      chrony_conf_mode:
+        description:
+          - "File mode of the chrony configuration file."
+          - "C(chronyd) parses it as root before dropping privileges, so it does not have to be group readable."
+          - "The packages ship it world readable and nothing in it is secret."
+        type: "str"
+        default: "0644"
+      chrony_service:
+        description:
+          - "Name of the chrony systemd unit."
+          - "The Debian family names the unit C(chrony.service) and only adds the C(chronyd.service) alias when the unit is enabled."
+          - "The Red Hat family names it C(chronyd.service) and has no C(chrony.service) at all."
+          - "Defaults to C(chrony.service) on the Debian family and to C(chronyd.service) otherwise."
+        type: "str"
+      chrony_user:
+        description:
+          - "User C(chronyd) drops its privileges to."
+          - "Defaults to C(_chrony) on the Debian family and to C(chrony) otherwise."
+        type: "str"
+      chrony_group:
+        description:
+          - "Group of the chrony daemon user."
+          - "Defaults to C(_chrony) on the Debian family and to C(chrony) otherwise."
+        type: "str"
+      chrony_driftfile:
+        description:
+          - "File in which C(chronyd) records the rate at which the system clock gains or loses time."
+          - "Defaults to C(/var/lib/chrony/chrony.drift) on the Debian family and to C(/var/lib/chrony/drift) otherwise."
+        type: "path"
+      chrony_ntsdumpdir:
+        description:
+          - "Directory in which C(chronyd) saves NTS keys and cookies."
+          - "It stops a restart from requiring a new NTS-KE session with every source."
+        type: "path"
+        default: "/var/lib/chrony"
+      chrony_dumpdir:
+        description:
+          - "Directory in which C(chronyd) saves the measurement history."
+          - "It has to be the runtime directory of the unit, which is the only writable path left by C(RuntimeDirectory=chrony) and C(ProtectSystem=strict)."
+        type: "path"
+        default: "/run/chrony"
+      chrony_logdir:
+        description: "Directory in which C(chronyd) writes its log files."
+        type: "path"
+        default: "/var/log/chrony"
+      chrony_sources:
+        description:
+          - "Time sources. Every source is emitted as C(<type> <address> <options>), where I(type) is either C(server) or C(pool)."
+          - "The default sources all support NTS, which is what makes C(chrony_authselectmode) set to C(require) usable."
+          - "Which organizations a host asks for the time is a supply chain decision, review the list before using it."
+        type: "list"
+        elements: "dict"
+        default:
+          - { "address": "time.cloudflare.com", "type": "server", "options": ["iburst", "nts"] }
+          - { "address": "ntppool1.time.nl", "type": "server", "options": ["iburst", "nts"] }
+          - { "address": "nts.netnod.se", "type": "server", "options": ["iburst", "nts"] }
+          - { "address": "ptbtime1.ptb.de", "type": "server", "options": ["iburst", "nts"] }
+      chrony_sourcedirs:
+        description:
+          - "Directories scanned for additional source files, C(sourcedir) directives."
+          - "Empty by default: the packaged configurations read C(/run/chrony-dhcp), which adds whatever unauthenticated servers a DHCP server hands out."
+        type: "list"
+        elements: "path"
+        default: []
+      chrony_confdirs:
+        description:
+          - "Directories scanned for additional configuration files, C(confdir) directives."
+          - "Empty by default so that the configuration of a host is the file this role manages and nothing else."
+        type: "list"
+        elements: "path"
+        default: []
+      chrony_minsources:
+        description: "Minimum number of selectable sources required to adjust the system clock."
+        type: "int"
+        default: 3
+      chrony_authselectmode:
+        description:
+          - "Authentication required for a source to be selected."
+          - "C(require) rejects every unauthenticated source, C(ignore) is the C(chronyd) default and selects sources regardless of authentication."
+          - "Set to an empty string to leave the directive out."
+          - "The role fails when this is C(require) and C(chrony_sources) contains a source without the C(nts) option."
+        type: "str"
+        default: "require"
+        choices:
+          - "require"
+          - "prefer"
+          - "mix"
+          - "ignore"
+          - ""
+      chrony_nocerttimecheck:
+        description:
+          - "Number of clock updates for which the NTS-KE certificate time checks are disabled."
+          - "Needed only to break the bootstrap deadlock on hosts that come up with a clock wrong enough to make every certificate look expired."
+          - "That stops NTS, which is the only way left to correct the clock."
+          - "C(0) keeps the checks."
+        type: "int"
+        default: 0
+      chrony_makestep:
+        description:
+          - "Threshold and limit of the C(makestep) directive."
+          - "Step the clock instead of slewing it if the correction is larger than the first value, for the first number of updates given by the second value."
+        type: "str"
+        default: "1.0 3"
+      chrony_rtcsync:
+        description: "If True, the real time clock is synchronized from the system clock every 11 minutes."
+        type: "bool"
+        default: true
+      chrony_rtconutc:
+        description:
+          - "If True, the real time clock is assumed to keep UTC."
+          - "Wrong for hosts that dual boot an operating system that keeps local time in the RTC."
+        type: "bool"
+        default: false
+      chrony_leapseclist:
+        description:
+          - "File containing the TAI-UTC offset and the leap seconds, C(leapseclist)."
+          - "The directive is only written when the file exists on the target, since it belongs to the tz database and not to chrony."
+        type: "path"
+        default: "/usr/share/zoneinfo/leap-seconds.list"
+      chrony_port:
+        description:
+          - "UDP port C(chronyd) listens on for NTP requests."
+          - "C(0) means the host is a client only and never answers NTP."
+        type: "int"
+        default: 0
+      chrony_cmdport:
+        description:
+          - "UDP port C(chronyd) listens on for C(chronyc) command packets."
+          - "C(0) disables it, C(chronyc) still works for root over the Unix domain socket."
+        type: "int"
+        default: 0
+      chrony_noclientlog:
+        description:
+          - "If True, no per client access logs are kept."
+          - "Only relevant when serving time, it stops the memory a remote client can make C(chronyd) allocate."
+        type: "bool"
+        default: true
+      chrony_conflicting_services:
+        description:
+          - "Services that also synchronize the system clock."
+          - "They are stopped and disabled so that chrony is the only time synchronization service on the host."
+        type: "list"
+        elements: "str"
+        default:
+          - "systemd-timesyncd.service"
+          - "ntp.service"
+          - "ntpd.service"
+          - "ntpsec.service"
+          - "openntpd.service"
+          - "ntpd-rs.service"
+          - "chronyd-restricted.service"
+      chrony_server_enabled:
+        description:
+          - "If True, the host serves time to the networks listed in C(chrony_server_allow)."
+          - "It requires C(chrony_port) to be a real port, the role fails otherwise."
+        type: "bool"
+        default: false
+      chrony_server_allow:
+        description:
+          - "Networks allowed to use the host as a time source, C(allow) directives."
+          - "An empty list serves nobody."
+        type: "list"
+        elements: "str"
+        default: []
+      chrony_ntsserverkey:
+        description:
+          - "Private key of the NTS server certificate."
+          - "On the Debian family it has to stay under C(/etc/chrony), the AppArmor profile of C(chronyd) denies reads anywhere else."
+          - "Defaults to C(/etc/chrony/nts-server.key) on the Debian family and to C(/etc/pki/tls/private/chrony-nts.key) otherwise."
+        type: "path"
+      chrony_ntsservercert:
+        description:
+          - "Certificate, or certificate chain, presented to NTS clients."
+          - "Defaults to C(/etc/chrony/nts-server.crt) on the Debian family and to C(/etc/pki/tls/certs/chrony-nts.crt) otherwise."
+        type: "path"
+      chrony_ntsserverkey_mode:
+        description:
+          - "File mode of C(chrony_ntsserverkey)."
+          - "It is owned by C(root) and readable by C(chrony_group), which is the account C(chronyd) drops to."
+        type: "str"
+        default: "0640"
+      chrony_ntsservercert_mode:
+        description: "File mode of C(chrony_ntsservercert)."
+        type: "str"
+        default: "0644"
+      chrony_ntsprocesses:
+        description: "Number of helper processes handling NTS-KE sessions."
+        type: "int"
+        default: 1
+      chrony_ratelimit_interval:
+        description: "Interval, as a power of two seconds, between responses to a client before C(chronyd) starts dropping requests."
+        type: "int"
+        default: 1
+      chrony_ratelimit_burst:
+        description: "Number of requests a client may send faster than C(chrony_ratelimit_interval) before C(chronyd) starts dropping them."
+        type: "int"
+        default: 16

--- a/roles/chrony/meta/argument_specs.yml
+++ b/roles/chrony/meta/argument_specs.yml
@@ -3,7 +3,8 @@ argument_specs:
   main:
     short_description: "chrony configuration."
     description:
-      - "This role configures chrony as a client only NTP daemon, using Network Time Security authenticated sources."
+      - "This role configures chrony as a client by default, using Network Time Security authenticated sources."
+      - "Serving time to other hosts is opt-in and enabled with C(chrony_server_enabled)."
       - "Any other time synchronization service is stopped and disabled, so that chrony is the only one running."
     author:
       - "Thomas Sjögren (@konstruktoid)"

--- a/roles/chrony/meta/main.yml
+++ b/roles/chrony/meta/main.yml
@@ -1,0 +1,28 @@
+---
+galaxy_info:
+  role_name: chrony
+  author: konstruktoid
+  description: "Ansible role to manage chrony configuration."
+  license: apache
+  min_ansible_version: "2.18"
+  platforms:
+    - name: Debian
+      versions:
+        - trixie
+    - name: EL
+      versions:
+        - "10"
+    - name: Ubuntu
+      versions:
+        - resolute
+  galaxy_tags:
+    - almalinux
+    - chrony
+    - cis
+    - debian
+    - disa
+    - hardening
+    - ntp
+    - security
+    - system
+    - ubuntu

--- a/roles/chrony/tasks/main.yml
+++ b/roles/chrony/tasks/main.yml
@@ -1,0 +1,145 @@
+---
+- name: Install and configure chrony
+  become: true
+  when:
+    - ansible_facts.virtualization_type not in ["container", "docker", "podman"]
+  block:
+    - name: Assert that the time sources are usable
+      ansible.builtin.assert:
+        that:
+          - chrony_sources | length > 0
+          - chrony_sources | rejectattr("type", "in", ["server", "pool"]) | list | length == 0
+        fail_msg: >-
+          chrony_sources has to contain at least one source, and the type of every
+          source has to be either "server" or "pool".
+
+    # chronyd parses "authselectmode require" together with an unauthenticated
+    # source without complaining and then never selects a source, leaving the
+    # clock unsynchronized, so the combination is rejected here instead.
+    - name: Assert that every time source is authenticated
+      ansible.builtin.assert:
+        that:
+          - chrony_sources | rejectattr("options", "contains", "nts") | list | length == 0
+        fail_msg: >-
+          chrony_authselectmode is "require", which lets chronyd select
+          authenticated sources only, but chrony_sources contains a source
+          without the "nts" option:
+          {{ chrony_sources | rejectattr("options", "contains", "nts") | map(attribute="address") | join(", ") }}
+      when: chrony_authselectmode == "require"
+
+    - name: Assert that a time server accepts NTP requests
+      ansible.builtin.assert:
+        that:
+          - chrony_port | int > 0
+        fail_msg: >-
+          chrony_server_enabled is true, but chrony_port is 0, which stops
+          chronyd from opening the NTP port at all. Set chrony_port to 123.
+      when: chrony_server_enabled
+
+    - name: Install chrony
+      ansible.builtin.package:
+        name: "{{ chrony_packages }}"
+        state: present
+
+    # leapseclist without the file makes chronyd exit, and the file belongs to
+    # the tz database, not to chrony, so it is not installed on every host.
+    - name: Stat the leap second list
+      ansible.builtin.stat:
+        path: "{{ chrony_leapseclist }}"
+        get_attributes: false
+        get_checksum: false
+        get_mime: false
+      register: chrony_leapseclist_stat
+
+    - name: Set the NTS server key and certificate ownership and permissions
+      ansible.builtin.file:
+        path: "{{ item.path }}"
+        state: file
+        owner: root
+        group: "{{ item.group }}"
+        mode: "{{ item.mode }}"
+      loop:
+        - path: "{{ chrony_ntsserverkey }}"
+          group: "{{ chrony_group }}"
+          mode: "{{ chrony_ntsserverkey_mode }}"
+        - path: "{{ chrony_ntsservercert }}"
+          group: "root"
+          mode: "{{ chrony_ntsservercert_mode }}"
+      loop_control:
+        label: "{{ item.path }}"
+      when: chrony_server_enabled
+
+    - name: Configure chrony
+      ansible.builtin.template:
+        src: "{{ chrony_conf_template }}"
+        dest: "{{ chrony_conf }}"
+        backup: true
+        mode: "{{ chrony_conf_mode }}"
+        owner: root
+        group: root
+      register: chrony_configuration
+      notify:
+        - Restart chrony
+
+    # The AppArmor profile shipped with the Debian family package only lets
+    # chronyd read /etc/chrony/** and /etc/chrony.*, so the configuration cannot
+    # be validated where the template module puts its temporary file. It is
+    # written first and parsed afterwards, and the backup is put back when
+    # chronyd rejects it.
+    - name: Validate the chrony configuration
+      when: not ansible_check_mode
+      block:
+        - name: Parse the chrony configuration
+          ansible.builtin.command:
+            cmd: "chronyd -f {{ chrony_conf }} -p"
+          changed_when: false
+      rescue:
+        - name: Restore the previous chrony configuration
+          ansible.builtin.copy:
+            src: "{{ chrony_configuration.backup_file }}"
+            dest: "{{ chrony_conf }}"
+            remote_src: true
+            mode: "{{ chrony_conf_mode }}"
+            owner: root
+            group: root
+          when: chrony_configuration.backup_file is defined
+
+        - name: Fail because chronyd rejected the configuration
+          ansible.builtin.fail:
+            msg: >-
+              chronyd rejected {{ chrony_conf }}.
+              {{ 'The previous configuration has been restored.'
+                 if chrony_configuration.backup_file is defined
+                 else 'There was no previous configuration to restore.' }}
+
+    - name: Gather service facts
+      ansible.builtin.service_facts:
+
+    # systemd-timedated picks the first unit listed in /usr/lib/systemd/ntp-units.d/
+    # and disables every other one, so the conflicting units are stopped and
+    # disabled before chrony is enabled and started. Doing it the other way
+    # round leaves the host synchronizing with whichever unit sorts first.
+    - name: Stop conflicting time synchronization services
+      ansible.builtin.systemd_service:
+        name: "{{ item }}"
+        state: stopped
+      loop: "{{ chrony_conflicting_services }}"
+      when:
+        - item in ansible_facts.services
+        - ansible_facts.services[item].state == "running"
+
+    - name: Disable conflicting time synchronization services
+      ansible.builtin.systemd_service:
+        name: "{{ item }}"
+        enabled: false
+      loop: "{{ chrony_conflicting_services }}"
+      when:
+        - item in ansible_facts.services
+        - ansible_facts.services[item].status in ["enabled", "enabled-runtime"]
+
+    - name: Start chrony
+      ansible.builtin.systemd_service:
+        name: "{{ chrony_service }}"
+        enabled: true
+        masked: false
+        state: started

--- a/roles/chrony/tasks/main.yml
+++ b/roles/chrony/tasks/main.yml
@@ -69,6 +69,14 @@
         label: "{{ item.path }}"
       when: chrony_server_enabled
 
+    - name: Stat the chrony configuration before rendering it
+      ansible.builtin.stat:
+        path: "{{ chrony_conf }}"
+        get_attributes: false
+        get_checksum: false
+        get_mime: false
+      register: chrony_conf_before
+
     - name: Configure chrony
       ansible.builtin.template:
         src: "{{ chrony_conf_template }}"
@@ -85,7 +93,9 @@
     # chronyd read /etc/chrony/** and /etc/chrony.*, so the configuration cannot
     # be validated where the template module puts its temporary file. It is
     # written first and parsed afterwards, and the backup is put back when
-    # chronyd rejects it.
+    # chronyd rejects it. A rejected configuration that had no file before the
+    # template task, and therefore no backup, is removed instead of being left
+    # behind for chronyd to read on the next start.
     - name: Validate the chrony configuration
       when: not ansible_check_mode
       block:
@@ -104,13 +114,23 @@
             group: root
           when: chrony_configuration.backup_file is defined
 
+        - name: Remove the rejected chrony configuration
+          ansible.builtin.file:
+            path: "{{ chrony_conf }}"
+            state: absent
+          when:
+            - chrony_configuration.backup_file is not defined
+            - not chrony_conf_before.stat.exists
+
         - name: Fail because chronyd rejected the configuration
           ansible.builtin.fail:
             msg: >-
               chronyd rejected {{ chrony_conf }}.
               {{ 'The previous configuration has been restored.'
                  if chrony_configuration.backup_file is defined
-                 else 'There was no previous configuration to restore.' }}
+                 else 'The rejected configuration has been removed.'
+                 if not chrony_conf_before.stat.exists
+                 else 'The previous configuration was unchanged and is still in place.' }}
 
     - name: Gather service facts
       ansible.builtin.service_facts:

--- a/roles/chrony/templates/etc/chrony/chrony.conf.j2
+++ b/roles/chrony/templates/etc/chrony/chrony.conf.j2
@@ -1,0 +1,68 @@
+#jinja2: trim_blocks: True, lstrip_blocks: True
+# Managed by Ansible role {{ ansible_role_name }}
+
+# Time sources.
+{% for source in chrony_sources %}
+{{ source.type }} {{ source.address }} {{ source.options | join(' ') }}
+{% endfor %}
+{% for sourcedir in chrony_sourcedirs %}
+sourcedir {{ sourcedir }}
+{% endfor %}
+{% for confdir in chrony_confdirs %}
+confdir {{ confdir }}
+{% endfor %}
+
+# Do not adjust the clock unless this many sources agree.
+minsources {{ chrony_minsources }}
+{% if chrony_authselectmode | length > 0 %}
+# Authentication required of a source before it can be selected.
+authselectmode {{ chrony_authselectmode }}
+{% endif %}
+{% if chrony_nocerttimecheck | int > 0 %}
+# Ignore the NTS certificate time checks for this many clock updates, so that a
+# host with a clock too far off to validate a certificate can still bootstrap.
+nocerttimecheck {{ chrony_nocerttimecheck }}
+{% endif %}
+
+# Drop privileges to this account once the sockets are open.
+user {{ chrony_user }}
+
+# State.
+driftfile {{ chrony_driftfile }}
+dumpdir {{ chrony_dumpdir }}
+ntsdumpdir {{ chrony_ntsdumpdir }}
+logdir {{ chrony_logdir }}
+
+# Step the clock instead of slewing it during the first updates.
+makestep {{ chrony_makestep }}
+{% if chrony_rtcsync %}
+# Synchronize the real time clock from the system clock.
+rtcsync
+{% endif %}
+{% if chrony_rtconutc %}
+# The real time clock keeps UTC.
+rtconutc
+{% endif %}
+{% if chrony_leapseclist | length > 0 and chrony_leapseclist_stat.stat.exists %}
+# TAI-UTC offset and leap seconds from the system tz database.
+leapseclist {{ chrony_leapseclist }}
+{% endif %}
+
+# Listening ports. 0 means the port is not opened at all.
+port {{ chrony_port }}
+cmdport {{ chrony_cmdport }}
+{% if chrony_noclientlog %}
+# Do not keep per client access logs.
+noclientlog
+{% endif %}
+{% if chrony_server_enabled %}
+
+# Serve time to these networks.
+{% for network in chrony_server_allow %}
+allow {{ network }}
+{% endfor %}
+ratelimit interval {{ chrony_ratelimit_interval }} burst {{ chrony_ratelimit_burst }}
+ntsserverkey {{ chrony_ntsserverkey }}
+ntsservercert {{ chrony_ntsservercert }}
+ntsprocesses {{ chrony_ntsprocesses }}
+{% endif %}

--- a/roles/timesyncd/README.md
+++ b/roles/timesyncd/README.md
@@ -8,6 +8,10 @@ This matters on distributions that ship a different NTP client by default, for e
 AlmaLinux and Ubuntu, where `chrony` otherwise takes over the clock again after a reboot and
 the servers configured by this role are never used.
 
+The [`chrony`](../chrony/README.md) role is the alternative, and does the same mutual exclusion in
+the other direction. The two roles are alternatives, do not apply both to the same host and
+expect both to keep running.
+
 On the Red Hat family `systemd-timesyncd` is only available from EPEL, so the role installs
 `epel-release`. Roles that add repositories have to run before any package upgrade, see the
 [`package_management`](../package_management/README.md) role.
@@ -33,7 +37,7 @@ Defined in `roles/timesyncd/defaults/main.yml`.
 | `fallback_ntp` | `["ntp.netnod.se", "ntp.ubuntu.com"]` | A list of NTP server host names or IP addresses to be used as the fallback NTP servers. |
 | `ntp` | `["2.pool.ntp.org", "time.nist.gov"]` | A list of NTP server host names or IP addresses to be used as the primary NTP servers. |
 | `timesyncd_conf_template` | `"etc/systemd/timesyncd.conf.j2"` | systemd timesyncd.conf template location. |
-| `timesyncd_conflicting_services` | `["chrony.service", "chronyd.service", "ntp.service", "ntpd.service", "ntpsec.service", "openntpd.service"]` | Services that also synchronize the system clock. They are stopped and disabled so that systemd-timesyncd is the only time synchronization service on the host. |
+| `timesyncd_conflicting_services` | `["chrony.service", "chronyd-restricted.service", "chronyd.service", "ntp.service", "ntpd-rs.service", "ntpd.service", "ntpsec.service", "openntpd.service"]` | Services that also synchronize the system clock. They are stopped and disabled so that systemd-timesyncd is the only time synchronization service on the host. |
 
 ## Tasks
 

--- a/roles/timesyncd/defaults/main.yml
+++ b/roles/timesyncd/defaults/main.yml
@@ -5,8 +5,10 @@ timesyncd_conf_template: "etc/systemd/timesyncd.conf.j2"
 # systemd-timesyncd is the only time synchronization service on the host.
 timesyncd_conflicting_services:
   - "chrony.service"
+  - "chronyd-restricted.service"
   - "chronyd.service"
   - "ntp.service"
+  - "ntpd-rs.service"
   - "ntpd.service"
   - "ntpsec.service"
   - "openntpd.service"

--- a/roles/timesyncd/meta/argument_specs.yml
+++ b/roles/timesyncd/meta/argument_specs.yml
@@ -20,8 +20,10 @@ argument_specs:
         elements: "str"
         default:
           - "chrony.service"
+          - "chronyd-restricted.service"
           - "chronyd.service"
           - "ntp.service"
+          - "ntpd-rs.service"
           - "ntpd.service"
           - "ntpsec.service"
           - "openntpd.service"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Chrony role for authenticated, client-only time synchronization.
  * Added optional time-serving support, NTS authentication, certificate handling, RTC synchronization, and rate limiting.
  * Added configuration validation and automatic handling of conflicting time-sync services.
* **Documentation**
  * Documented Chrony configuration, supported platforms, and usage guidance.
  * Clarified that Chrony and Timesyncd should not be applied to the same host.
* **Tests**
  * Added verification coverage for service status, synchronization, configuration, and NTS health.
  * Updated scenario coverage to validate Chrony.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->