### PR TITLE
update delete_users role regarding recreation of users

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>

### DIFF
--- a/extensions/molecule/tests/verify_delete_users.yml
+++ b/extensions/molecule/tests/verify_delete_users.yml
@@ -1,1 +1,11 @@
 ---
+- name: Get passwd database
+  ansible.builtin.getent:
+    database: passwd
+
+- name: Assert users in delete_users are absent
+  ansible.builtin.assert:
+    that:
+      - delete_users | intersect(ansible_facts.getent_passwd.keys() | list) | length == 0
+    fail_msg: "Users that should have been deleted are present: {{ delete_users | intersect(ansible_facts.getent_passwd.keys() | list) }}"
+    success_msg: "All users in delete_users are absent."

--- a/roles/delete_users/README.md
+++ b/roles/delete_users/README.md
@@ -30,8 +30,10 @@ package hooks recreate them after this role has removed them:
 - `systemd` ships `/usr/lib/sysusers.d/basic.conf`, generated from `base-passwd`'s `passwd.master`,
   and `dh_installsysusers` adds `systemd-sysusers basic.conf ...` to `systemd.postinst`. Every
   install or upgrade of the `systemd` package therefore recreates `games`, `irc`, `list`, `news`,
-  `sync` and `uucp`. Any package shipping a `sysusers.d` file gets the same postinst snippet, so
-  `systemd` is not the only possible trigger.
+  `sync` and `uucp`. The postinst snippet a package gets from `dh_installsysusers` only processes
+  the `sysusers.d` files that package itself declares and installs, not everything in
+  `/usr/lib/sysusers.d/`, so these accounts return when `systemd`, or any other package shipping
+  and processing `basic.conf`, is installed or upgraded.
 - `base-passwd.postinst` runs `update-passwd` on every *upgrade* of `base-passwd`. When debconf is
   available, which it is on a normal system, it runs unprompted and recreates every account listed
   in `passwd.master`.
@@ -39,9 +41,11 @@ package hooks recreate them after this role has removed them:
 Two consequences:
 
 - Run this role **after** every role or task that installs or upgrades packages. Placing it early
-  in a play that later pulls in `systemd`, for example through `konstruktoid.hardening.resolvedconf`
-  installing `systemd-resolved`, leaves the accounts present at the end of the run and makes the
-  play non-idempotent.
+  in a play that later installs or upgrades `systemd`, for example through
+  `konstruktoid.hardening.resolvedconf` pulling a `systemd` install or upgrade into the same
+  transaction as `systemd-resolved`, leaves the accounts present at the end of the run and makes
+  the play non-idempotent. Installing `systemd-resolved` on its own only creates the
+  `systemd-resolve` user, since its postinst processes `systemd-resolve.conf` and not `basic.conf`.
 - Even with correct ordering the removal is not permanent. A later `systemd` or `base-passwd`
   upgrade, including one applied by unattended upgrades, brings the accounts back. Re-run the role
   periodically if their absence has to hold over time.

--- a/roles/delete_users/README.md
+++ b/roles/delete_users/README.md
@@ -22,6 +22,35 @@ Defined in `roles/delete_users/defaults/main.yml`.
 | --- | --- | --- |
 | `delete_users` | `["games", "gnats", "irc", "list", "news", "sync", "uucp"]` | List of users to delete. |
 
+## Notes
+
+On the Debian family the default accounts are owned by the packaging system, and two independent
+package hooks recreate them after this role has removed them:
+
+- `systemd` ships `/usr/lib/sysusers.d/basic.conf`, generated from `base-passwd`'s `passwd.master`,
+  and `dh_installsysusers` adds `systemd-sysusers basic.conf ...` to `systemd.postinst`. Every
+  install or upgrade of the `systemd` package therefore recreates `games`, `irc`, `list`, `news`,
+  `sync` and `uucp`. Any package shipping a `sysusers.d` file gets the same postinst snippet, so
+  `systemd` is not the only possible trigger.
+- `base-passwd.postinst` runs `update-passwd` on every *upgrade* of `base-passwd`. When debconf is
+  available, which it is on a normal system, it runs unprompted and recreates every account listed
+  in `passwd.master`.
+
+Two consequences:
+
+- Run this role **after** every role or task that installs or upgrades packages. Placing it early
+  in a play that later pulls in `systemd`, for example through `konstruktoid.hardening.resolvedconf`
+  installing `systemd-resolved`, leaves the accounts present at the end of the run and makes the
+  play non-idempotent.
+- Even with correct ordering the removal is not permanent. A later `systemd` or `base-passwd`
+  upgrade, including one applied by unattended upgrades, brings the accounts back. Re-run the role
+  periodically if their absence has to hold over time.
+
+The `sysusers.d` path can be suppressed with a filtered copy of `basic.conf` in `/etc/sysusers.d/`,
+which takes precedence over the one in `/usr/lib/sysusers.d/`. This role does not do that, because
+the override masks the vendor file wholesale and would also hide accounts added to it by future
+package updates, and because it does not stop the `update-passwd` path.
+
 ## Tasks
 
 `tasks/main.yml` executes, in order:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added verification that the password database loads correctly.
  - Confirmed that all configured accounts marked for deletion are absent, with clear success and failure reporting.

- **Documentation**
  - Documented package hooks that may recreate deleted default accounts.
  - Clarified account-removal ordering, non-permanent deletion behavior, and limitations when suppressing system user definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->