### PR TITLE
dont carry local development state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## 0.3.2 (2026-08-19)
+
+- Sync `build_ignore` in `galaxy.yml` with `.gitignore`, so that the built collection artifact
+  no longer carries local development state. Directory patterns were written with a trailing
+  slash (`.ansible/`, `.github/`), which `ansible-galaxy collection build` matches against
+  paths without one, so those entries never took effect and the downloaded collections under
+  `.ansible/` were bundled. `.gitignore` entries that had no `build_ignore` counterpart at all
+  (`*.gz`, `molecule-logs/`, `.claude/`) are added, together with the local agent and linter
+  configuration (`.agents`, `.ansible-lint`, `.ansible-lint-ignore`, `CLAUDE.md`). The artifact
+  goes from 26M to 950K and now contains only files tracked in git. This release contains no
+  other changes.
+
 ## 0.3.1 (2026-08-19)
 
 - Set the collection version in `galaxy.yml` to `0.3.1`. The `v0.3.0` tag was cut while

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: konstruktoid
 name: hardening
-version: 0.3.1
+version: 0.3.2
 readme: README.md
 authors:
   - "Thomas Sjögren (@konstruktoid)"
@@ -26,14 +26,21 @@ tags:
   - systemd
   - ubuntu
 build_ignore:
-  - .ansible/
-  - ansible.cfg
-  - ansible_collections
+  - "*.gz"
+  - .agents
+  - .ansible
+  - .ansible-lint
+  - .ansible-lint-ignore
   - .cache
+  - .claude
   - .env
   - .env.yml
-  - .github/
+  - .github
   - .nox
   - .tox
   - .venv
   - .yamllint
+  - CLAUDE.md
+  - ansible.cfg
+  - ansible_collections
+  - molecule-logs


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the collection version to 0.3.2.
  * Improved release packaging to exclude local development files and state.
  * Corrected directory-pattern handling and included previously omitted development files.
  * Reduced collection artifact size from 26 MB to approximately 950 KB.
  * Confirmed packaged artifacts contain only tracked files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->